### PR TITLE
[Migration] `core` 모듈 마이그레이션 진행

### DIFF
--- a/common/src/main/kotlin/kr/spot/common/api/ApiResponse.kt
+++ b/common/src/main/kotlin/kr/spot/common/api/ApiResponse.kt
@@ -17,7 +17,10 @@ data class ApiResponse<T>(
 ) {
     companion object {
         // 성공 응답 (데이터 있음)
-        fun <T> success(status: SuccessStatus, result: T): ApiResponse<T> =
+        fun <T> success(
+            status: SuccessStatus,
+            result: T
+        ): ApiResponse<T> =
             ApiResponse(
                 isSuccess = true,
                 code = status.code,
@@ -36,14 +39,19 @@ data class ApiResponse<T>(
 
         // 성공 응답 - OK 기본값
         fun <T> ok(result: T): ApiResponse<T> = success(SuccessStatus.OK, result)
+
         fun ok(): ApiResponse<Unit> = success(SuccessStatus.OK)
 
         // 성공 응답 - CREATED
         fun <T> created(result: T): ApiResponse<T> = success(SuccessStatus.CREATED, result)
+
         fun created(): ApiResponse<Unit> = success(SuccessStatus.CREATED)
 
         // 실패 응답
-        fun <T> failure(status: ErrorStatus, result: T? = null): ApiResponse<T> =
+        fun <T> failure(
+            status: ErrorStatus,
+            result: T? = null
+        ): ApiResponse<T> =
             ApiResponse(
                 isSuccess = false,
                 code = status.code,
@@ -52,7 +60,11 @@ data class ApiResponse<T>(
             )
 
         // 실패 응답 (커스텀 메시지)
-        fun <T> failure(code: String, message: String, result: T? = null): ApiResponse<T> =
+        fun <T> failure(
+            code: String,
+            message: String,
+            result: T? = null
+        ): ApiResponse<T> =
             ApiResponse(
                 isSuccess = false,
                 code = code,

--- a/common/src/main/kotlin/kr/spot/common/api/BaseCode.kt
+++ b/common/src/main/kotlin/kr/spot/common/api/BaseCode.kt
@@ -6,10 +6,11 @@ interface BaseCode {
     val message: String
     val isSuccess: Boolean
 
-    fun toReasonDto(): ReasonDto = ReasonDto(
-        isSuccess = isSuccess,
-        code = code,
-        message = message,
-        httpStatus = httpStatus
-    )
+    fun toReasonDto(): ReasonDto =
+        ReasonDto(
+            isSuccess = isSuccess,
+            code = code,
+            message = message,
+            httpStatus = httpStatus
+        )
 }

--- a/common/src/main/kotlin/kr/spot/common/api/status/ErrorStatus.kt
+++ b/common/src/main/kotlin/kr/spot/common/api/status/ErrorStatus.kt
@@ -7,7 +7,6 @@ enum class ErrorStatus(
     override val code: String,
     override val message: String
 ) : BaseCode {
-
     // 공통 에러
     INTERNAL_SERVER_ERROR(500, "COMMON500", "서버 내부 오류 발생"),
     BAD_REQUEST(400, "COMMON4000", "잘못된 요청입니다."),

--- a/common/src/main/kotlin/kr/spot/common/api/status/SuccessStatus.kt
+++ b/common/src/main/kotlin/kr/spot/common/api/status/SuccessStatus.kt
@@ -7,7 +7,6 @@ enum class SuccessStatus(
     override val code: String,
     override val message: String
 ) : BaseCode {
-
     OK(200, "COMMON200", "OK"),
     CREATED(201, "COMMON201", "생성 완료"),
     ACCEPTED(202, "COMMON202", "요청 수락됨"),

--- a/common/src/main/kotlin/kr/spot/common/config/IdGeneratorConfig.kt
+++ b/common/src/main/kotlin/kr/spot/common/config/IdGeneratorConfig.kt
@@ -1,0 +1,13 @@
+package kr.spot.common.config
+
+import kr.spot.common.id.IdGenerator
+import kr.spot.common.id.Snowflake
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class IdGeneratorConfig {
+
+    @Bean
+    fun idGenerator(): IdGenerator = Snowflake()
+}

--- a/common/src/main/kotlin/kr/spot/common/config/IdGeneratorConfig.kt
+++ b/common/src/main/kotlin/kr/spot/common/config/IdGeneratorConfig.kt
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 class IdGeneratorConfig {
-
     @Bean
     fun idGenerator(): IdGenerator = Snowflake()
 }

--- a/common/src/main/kotlin/kr/spot/common/id/Snowflake.kt
+++ b/common/src/main/kotlin/kr/spot/common/id/Snowflake.kt
@@ -2,11 +2,9 @@ package kr.spot.common.id
 
 import kotlin.random.Random
 
-
 class Snowflake(
     private val nodeId: Long = Random.nextLong(MAX_NODE_ID + 1)
 ) : IdGenerator {
-
     private var lastTimeMillis: Long = START_TIME_MILLIS
     private var sequence: Long = 0L
 
@@ -36,8 +34,8 @@ class Snowflake(
         lastTimeMillis = currentTimeMillis
 
         return ((currentTimeMillis - START_TIME_MILLIS) shl (NODE_ID_BITS + SEQUENCE_BITS)) or
-                (nodeId shl SEQUENCE_BITS) or
-                sequence
+            (nodeId shl SEQUENCE_BITS) or
+            sequence
     }
 
     private fun waitNextMillis(currentTimestamp: Long): Long {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -13,8 +13,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
     // Spring Security + OAuth2
-    implementation("org.springframework.boot:spring-boot-starter-security")
-    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+//    implementation("org.springframework.boot:spring-boot-starter-security")
+//    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 
     // JWT
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")

--- a/core/src/main/kotlin/kr/spot/core/CoreApplication.kt
+++ b/core/src/main/kotlin/kr/spot/core/CoreApplication.kt
@@ -2,8 +2,9 @@ package kr.spot.core
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = ["kr.spot.core", "kr.spot.common"])
 class CoreApplication
 
 fun main(args: Array<String>) {

--- a/core/src/main/kotlin/kr/spot/core/CoreApplication.kt
+++ b/core/src/main/kotlin/kr/spot/core/CoreApplication.kt
@@ -2,7 +2,6 @@ package kr.spot.core
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @SpringBootApplication(scanBasePackages = ["kr.spot.core", "kr.spot.common"])
 class CoreApplication

--- a/core/src/main/kotlin/kr/spot/core/global/domain/BaseEntity.kt
+++ b/core/src/main/kotlin/kr/spot/core/global/domain/BaseEntity.kt
@@ -1,10 +1,10 @@
-package kr.spot.core.shared.domain
+package kr.spot.core.global.domain
 
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.MappedSuperclass
-import kr.spot.core.shared.domain.enums.Status
+import kr.spot.core.global.domain.enums.Status
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener

--- a/core/src/main/kotlin/kr/spot/core/global/domain/BaseEntity.kt
+++ b/core/src/main/kotlin/kr/spot/core/global/domain/BaseEntity.kt
@@ -13,7 +13,6 @@ import java.time.LocalDateTime
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)
 abstract class BaseEntity {
-
     @CreatedDate
     var createdAt: LocalDateTime? = null
         protected set

--- a/core/src/main/kotlin/kr/spot/core/global/domain/enums/Status.kt
+++ b/core/src/main/kotlin/kr/spot/core/global/domain/enums/Status.kt
@@ -1,4 +1,4 @@
-package kr.spot.core.shared.domain.enums
+package kr.spot.core.global.domain.enums
 
 enum class Status {
     ACTIVE,

--- a/core/src/main/kotlin/kr/spot/core/global/infrastructure/JpaConfig.kt
+++ b/core/src/main/kotlin/kr/spot/core/global/infrastructure/JpaConfig.kt
@@ -5,5 +5,4 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @Configuration
 @EnableJpaAuditing
-class JpaConfig {
-}
+class JpaConfig

--- a/core/src/main/kotlin/kr/spot/core/global/infrastructure/JpaConfig.kt
+++ b/core/src/main/kotlin/kr/spot/core/global/infrastructure/JpaConfig.kt
@@ -1,4 +1,4 @@
-package kr.spot.core.shared.infrastructure
+package kr.spot.core.global.infrastructure
 
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing

--- a/core/src/main/kotlin/kr/spot/core/global/infrastructure/WebConfig.kt
+++ b/core/src/main/kotlin/kr/spot/core/global/infrastructure/WebConfig.kt
@@ -1,0 +1,22 @@
+package kr.spot.core.global.infrastructure
+
+import kr.spot.core.global.interceptor.MemberIdInterceptor
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig(
+    private val memberIdInterceptor: MemberIdInterceptor
+) : WebMvcConfigurer {
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(memberIdInterceptor)
+            .addPathPatterns("/api/**")
+            .excludePathPatterns(
+                "/api/health",
+                "/swagger-ui/**",
+                "/v3/api-docs/**"
+            )
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/global/infrastructure/WebConfig.kt
+++ b/core/src/main/kotlin/kr/spot/core/global/infrastructure/WebConfig.kt
@@ -9,9 +9,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 class WebConfig(
     private val memberIdInterceptor: MemberIdInterceptor
 ) : WebMvcConfigurer {
-
     override fun addInterceptors(registry: InterceptorRegistry) {
-        registry.addInterceptor(memberIdInterceptor)
+        registry
+            .addInterceptor(memberIdInterceptor)
             .addPathPatterns("/api/**")
             .excludePathPatterns(
                 "/api/health",

--- a/core/src/main/kotlin/kr/spot/core/global/interceptor/MemberIdInterceptor.kt
+++ b/core/src/main/kotlin/kr/spot/core/global/interceptor/MemberIdInterceptor.kt
@@ -1,0 +1,39 @@
+package kr.spot.core.global.interceptor
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+
+/**
+ * 헤더에서 Member ID를 추출하여 Request Attribute에 저장하는 인터셉터
+ *
+ * 사용법:
+ * - 요청 시 헤더에 X-Member-Id: {memberId} 추가
+ * - 컨트롤러에서 @RequestAttribute("memberId") memberId: Long 으로 받기
+ */
+@Component
+class MemberIdInterceptor : HandlerInterceptor {
+
+    companion object {
+        const val HEADER_NAME = "X-Member-Id"
+        const val ATTRIBUTE_NAME = "memberId"
+    }
+
+    override fun preHandle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any
+    ): Boolean {
+        val memberIdHeader = request.getHeader(HEADER_NAME)
+
+        if (memberIdHeader != null) {
+            val memberId = memberIdHeader.toLongOrNull()
+            if (memberId != null) {
+                request.setAttribute(ATTRIBUTE_NAME, memberId)
+            }
+        }
+
+        return true
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/global/interceptor/MemberIdInterceptor.kt
+++ b/core/src/main/kotlin/kr/spot/core/global/interceptor/MemberIdInterceptor.kt
@@ -14,7 +14,6 @@ import org.springframework.web.servlet.HandlerInterceptor
  */
 @Component
 class MemberIdInterceptor : HandlerInterceptor {
-
     companion object {
         const val HEADER_NAME = "X-Member-Id"
         const val ATTRIBUTE_NAME = "memberId"

--- a/core/src/main/kotlin/kr/spot/core/member/application/MemberCommandService.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/application/MemberCommandService.kt
@@ -21,24 +21,31 @@ class MemberCommandService(
     private val preferredCategoryRepository: PreferredCategoryRepository,
     private val preferredRegionRepository: PreferredRegionRepository
 ) {
-
     /**
      * 테스트용 회원 생성
      */
-    fun createTestMember(name: String, email: String): Long {
-        val member = Member.of(
-            id = idGenerator.nextId(),
-            email = Email.of(email),
-            name = name,
-            loginType = LoginType.KAKAO,  // 테스트용 기본값
-            profileImageUrl = null
-        )
+    fun createTestMember(
+        name: String,
+        email: String
+    ): Long {
+        val member =
+            Member.of(
+                id = idGenerator.nextId(),
+                email = Email.of(email),
+                name = name,
+                loginType = LoginType.KAKAO, // 테스트용 기본값
+                profileImageUrl = null
+            )
         return memberRepository.save(member).id
     }
+
     /**
      * 회원 이름 수정
      */
-    fun updateName(memberId: Long, newName: String) {
+    fun updateName(
+        memberId: Long,
+        newName: String
+    ) {
         val member = memberRepository.findByIdOrThrow(memberId)
         member.updateName(newName)
     }
@@ -57,36 +64,44 @@ class MemberCommandService(
     /**
      * 회원 선호 카테고리 등록
      */
-    fun registerPreferCategories(memberId: Long, categories: List<String>) {
+    fun registerPreferCategories(
+        memberId: Long,
+        categories: List<String>
+    ) {
         // 기존 선호 카테고리 삭제
         preferredCategoryRepository.deleteAllByMemberId(memberId)
 
         // 새로운 선호 카테고리 저장
-        val preferredCategories = categories.map { category ->
-            PreferredCategory.of(
-                id = idGenerator.nextId(),
-                memberId = memberId,
-                category = category
-            )
-        }
+        val preferredCategories =
+            categories.map { category ->
+                PreferredCategory.of(
+                    id = idGenerator.nextId(),
+                    memberId = memberId,
+                    category = category
+                )
+            }
         preferredCategoryRepository.saveAll(preferredCategories)
     }
 
     /**
      * 회원 선호 지역 등록
      */
-    fun registerPreferRegions(memberId: Long, regions: List<String>) {
+    fun registerPreferRegions(
+        memberId: Long,
+        regions: List<String>
+    ) {
         // 기존 선호 지역 삭제
         preferredRegionRepository.deleteAllByMemberId(memberId)
 
         // 새로운 선호 지역 저장
-        val preferredRegions = regions.map { region ->
-            PreferredRegion.of(
-                id = idGenerator.nextId(),
-                memberId = memberId,
-                regionCode = region
-            )
-        }
+        val preferredRegions =
+            regions.map { region ->
+                PreferredRegion.of(
+                    id = idGenerator.nextId(),
+                    memberId = memberId,
+                    regionCode = region
+                )
+            }
         preferredRegionRepository.saveAll(preferredRegions)
     }
 }

--- a/core/src/main/kotlin/kr/spot/core/member/application/MemberCommandService.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/application/MemberCommandService.kt
@@ -1,10 +1,11 @@
 package kr.spot.core.member.application
 
-import kr.spot.common.api.status.ErrorStatus
-import kr.spot.common.exception.GeneralException
 import kr.spot.common.id.IdGenerator
+import kr.spot.core.member.domain.Member
 import kr.spot.core.member.domain.PreferredCategory
 import kr.spot.core.member.domain.PreferredRegion
+import kr.spot.core.member.domain.enums.LoginType
+import kr.spot.core.member.domain.vo.Email
 import kr.spot.core.member.infrastructure.MemberRepository
 import kr.spot.core.member.infrastructure.PreferredCategoryRepository
 import kr.spot.core.member.infrastructure.PreferredRegionRepository
@@ -19,8 +20,21 @@ class MemberCommandService(
     private val memberRepository: MemberRepository,
     private val preferredCategoryRepository: PreferredCategoryRepository,
     private val preferredRegionRepository: PreferredRegionRepository
-
 ) {
+
+    /**
+     * 테스트용 회원 생성
+     */
+    fun createTestMember(name: String, email: String): Long {
+        val member = Member.of(
+            id = idGenerator.nextId(),
+            email = Email.of(email),
+            name = name,
+            loginType = LoginType.KAKAO,  // 테스트용 기본값
+            profileImageUrl = null
+        )
+        return memberRepository.save(member).id
+    }
     /**
      * 회원 이름 수정
      */

--- a/core/src/main/kotlin/kr/spot/core/member/application/MemberCommandService.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/application/MemberCommandService.kt
@@ -1,0 +1,78 @@
+package kr.spot.core.member.application
+
+import kr.spot.common.api.status.ErrorStatus
+import kr.spot.common.exception.GeneralException
+import kr.spot.common.id.IdGenerator
+import kr.spot.core.member.domain.PreferredCategory
+import kr.spot.core.member.domain.PreferredRegion
+import kr.spot.core.member.infrastructure.MemberRepository
+import kr.spot.core.member.infrastructure.PreferredCategoryRepository
+import kr.spot.core.member.infrastructure.PreferredRegionRepository
+import kr.spot.core.member.infrastructure.findByIdOrThrow
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class MemberCommandService(
+    private val idGenerator: IdGenerator,
+    private val memberRepository: MemberRepository,
+    private val preferredCategoryRepository: PreferredCategoryRepository,
+    private val preferredRegionRepository: PreferredRegionRepository
+
+) {
+    /**
+     * 회원 이름 수정
+     */
+    fun updateName(memberId: Long, newName: String) {
+        val member = memberRepository.findByIdOrThrow(memberId)
+        member.updateName(newName)
+    }
+
+    /**
+     * 회원 탈퇴
+     * TODO: 스터디장인 경우 탈퇴 불가 검증 (study 모듈 의존)
+     * TODO: 탈퇴 후 이벤트 발행 (MemberWithdrawnEvent)
+     */
+    fun withdraw(memberId: Long) {
+        // TODO: hasActiveStudyAsLeader 검증
+        memberRepository.deleteById(memberId)
+        // TODO: eventPublisher.publishEvent(MemberWithdrawnEvent(memberId))
+    }
+
+    /**
+     * 회원 선호 카테고리 등록
+     */
+    fun registerPreferCategories(memberId: Long, categories: List<String>) {
+        // 기존 선호 카테고리 삭제
+        preferredCategoryRepository.deleteAllByMemberId(memberId)
+
+        // 새로운 선호 카테고리 저장
+        val preferredCategories = categories.map { category ->
+            PreferredCategory.of(
+                id = idGenerator.nextId(),
+                memberId = memberId,
+                category = category
+            )
+        }
+        preferredCategoryRepository.saveAll(preferredCategories)
+    }
+
+    /**
+     * 회원 선호 지역 등록
+     */
+    fun registerPreferRegions(memberId: Long, regions: List<String>) {
+        // 기존 선호 지역 삭제
+        preferredRegionRepository.deleteAllByMemberId(memberId)
+
+        // 새로운 선호 지역 저장
+        val preferredRegions = regions.map { region ->
+            PreferredRegion.of(
+                id = idGenerator.nextId(),
+                memberId = memberId,
+                regionCode = region
+            )
+        }
+        preferredRegionRepository.saveAll(preferredRegions)
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/member/application/MemberExternalService.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/application/MemberExternalService.kt
@@ -38,13 +38,14 @@ class MemberExternalService(
         }
 
         // 신규 회원 생성
-        val member = Member.of(
-            id = idGenerator.nextId(),
-            email = emailVo,
-            name = nickname,
-            loginType = loginType,
-            profileImageUrl = imageUrl
-        )
+        val member =
+            Member.of(
+                id = idGenerator.nextId(),
+                email = emailVo,
+                name = nickname,
+                loginType = loginType,
+                profileImageUrl = imageUrl
+            )
         return memberRepository.save(member).id
     }
 
@@ -52,18 +53,19 @@ class MemberExternalService(
      * 여러 회원 정보 조회 (study 모듈에서 사용)
      */
     @Transactional(readOnly = true)
-    fun getMemberInfoMap(memberIds: List<Long>): Map<Long, MemberInfo> {
-        return memberRepository.findAllById(memberIds)
+    fun getMemberInfoMap(memberIds: List<Long>): Map<Long, MemberInfo> =
+        memberRepository
+            .findAllById(memberIds)
             .associate { it.id to MemberInfo(it.name, it.profileImageUrl) }
-    }
 
     /**
      * 작성자 정보 조회 (study 모듈에서 사용)
      */
     @Transactional(readOnly = true)
     fun getWriterInfo(memberId: Long): WriterInfo {
-        val member = memberRepository.findById(memberId).orElse(null)
-            ?: return WriterInfo(memberId, "알 수 없음", null)
+        val member =
+            memberRepository.findById(memberId).orElse(null)
+                ?: return WriterInfo(memberId, "알 수 없음", null)
         return WriterInfo(member.id, member.name, member.profileImageUrl)
     }
 

--- a/core/src/main/kotlin/kr/spot/core/member/application/MemberExternalService.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/application/MemberExternalService.kt
@@ -1,0 +1,80 @@
+package kr.spot.core.member.application
+
+import kr.spot.common.id.IdGenerator
+import kr.spot.core.member.domain.Member
+import kr.spot.core.member.domain.enums.LoginType
+import kr.spot.core.member.domain.vo.Email
+import kr.spot.core.member.infrastructure.MemberRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 외부 모듈(auth, study 등)에서 호출하는 서비스
+ */
+@Service
+class MemberExternalService(
+    private val idGenerator: IdGenerator,
+    private val memberRepository: MemberRepository
+) {
+    /**
+     * OAuth 로그인 후 회원 조회 또는 생성
+     * - 기존 회원이면 ID 반환
+     * - 신규 회원이면 생성 후 ID 반환
+     */
+    @Transactional
+    fun ensureFromOAuth(
+        provider: String,
+        email: String,
+        nickname: String,
+        imageUrl: String?
+    ): Long {
+        val loginType = LoginType.valueOf(provider.uppercase())
+        val emailVo = Email.of(email)
+
+        // 기존 회원 확인
+        val existingMember = memberRepository.findByEmailAndLoginType(emailVo, loginType)
+        if (existingMember != null) {
+            return existingMember.id
+        }
+
+        // 신규 회원 생성
+        val member = Member.of(
+            id = idGenerator.nextId(),
+            email = emailVo,
+            name = nickname,
+            loginType = loginType,
+            profileImageUrl = imageUrl
+        )
+        return memberRepository.save(member).id
+    }
+
+    /**
+     * 여러 회원 정보 조회 (study 모듈에서 사용)
+     */
+    @Transactional(readOnly = true)
+    fun getMemberInfoMap(memberIds: List<Long>): Map<Long, MemberInfo> {
+        return memberRepository.findAllById(memberIds)
+            .associate { it.id to MemberInfo(it.name, it.profileImageUrl) }
+    }
+
+    /**
+     * 작성자 정보 조회 (study 모듈에서 사용)
+     */
+    @Transactional(readOnly = true)
+    fun getWriterInfo(memberId: Long): WriterInfo {
+        val member = memberRepository.findById(memberId).orElse(null)
+            ?: return WriterInfo(memberId, "알 수 없음", null)
+        return WriterInfo(member.id, member.name, member.profileImageUrl)
+    }
+
+    data class MemberInfo(
+        val name: String,
+        val profileImageUrl: String?
+    )
+
+    data class WriterInfo(
+        val memberId: Long,
+        val name: String,
+        val profileImageUrl: String?
+    )
+}

--- a/core/src/main/kotlin/kr/spot/core/member/application/MemberQueryService.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/application/MemberQueryService.kt
@@ -1,7 +1,10 @@
 package kr.spot.core.member.application
 
 import kr.spot.core.member.domain.Member
-import kr.spot.core.member.infrastructure.*
+import kr.spot.core.member.infrastructure.MemberRepository
+import kr.spot.core.member.infrastructure.PreferredCategoryRepository
+import kr.spot.core.member.infrastructure.PreferredRegionRepository
+import kr.spot.core.member.infrastructure.findByIdOrThrow
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -28,16 +31,16 @@ class MemberQueryService(
     /**
      * 선호 카테고리 조회
      */
-    fun getPreferredCategories(memberId: Long): List<String> {
-        return preferredCategoryRepository.findAllByMemberId(memberId)
+    fun getPreferredCategories(memberId: Long): List<String> =
+        preferredCategoryRepository
+            .findAllByMemberId(memberId)
             .map { it.category }
-    }
 
     /**
      * 선호 지역 조회
      */
-    fun getPreferredRegions(memberId: Long): List<String> {
-        return preferredRegionRepository.findAllByMemberId(memberId)
+    fun getPreferredRegions(memberId: Long): List<String> =
+        preferredRegionRepository
+            .findAllByMemberId(memberId)
             .map { it.regionCode }
-    }
 }

--- a/core/src/main/kotlin/kr/spot/core/member/application/MemberQueryService.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/application/MemberQueryService.kt
@@ -1,0 +1,43 @@
+package kr.spot.core.member.application
+
+import kr.spot.core.member.domain.Member
+import kr.spot.core.member.infrastructure.*
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class MemberQueryService(
+    private val memberRepository: MemberRepository,
+    private val preferredCategoryRepository: PreferredCategoryRepository,
+    private val preferredRegionRepository: PreferredRegionRepository
+) {
+    /**
+     * 회원 정보 조회
+     */
+    fun getMember(memberId: Long): Member = memberRepository.findByIdOrThrow(memberId)
+
+    /**
+     * 회원 이름 조회
+     */
+    fun getMemberName(memberId: Long): String {
+        val member = memberRepository.findByIdOrThrow(memberId)
+        return member.name
+    }
+
+    /**
+     * 선호 카테고리 조회
+     */
+    fun getPreferredCategories(memberId: Long): List<String> {
+        return preferredCategoryRepository.findAllByMemberId(memberId)
+            .map { it.category }
+    }
+
+    /**
+     * 선호 지역 조회
+     */
+    fun getPreferredRegions(memberId: Long): List<String> {
+        return preferredRegionRepository.findAllByMemberId(memberId)
+            .map { it.regionCode }
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/member/domain/Member.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/domain/Member.kt
@@ -1,0 +1,56 @@
+package kr.spot.core.member.domain
+
+import jakarta.persistence.*
+import kr.spot.common.api.status.ErrorStatus
+import kr.spot.common.exception.GeneralException
+import kr.spot.core.member.domain.enums.LoginType
+import kr.spot.core.member.domain.vo.Email
+import kr.spot.core.shared.domain.BaseEntity
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
+
+@Entity
+@Table(name = "member")
+@SQLDelete(sql = "UPDATE member SET status = 'INACTIVE' WHERE id = ?")
+@SQLRestriction("status = 'ACTIVE'")
+class Member private constructor(
+    @Id
+    val id: Long,
+
+    @Embedded
+    @AttributeOverride(name = "value", column = Column(name = "email", nullable = false, unique = true))
+    val email: Email,
+
+    @Column(nullable = false)
+    var name: String,
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    val loginType: LoginType,
+
+    @Column
+    var profileImageUrl: String? = null
+) : BaseEntity() {
+
+    fun updateName(newName: String) {
+        require(newName.isNotBlank()) {
+            throw GeneralException(ErrorStatus.NAME_CAN_NOT_NULL_OR_EMPTY)
+        }
+        this.name = newName
+    }
+
+    companion object {
+        fun of(
+            id: Long,
+            email: Email,
+            name: String,
+            loginType: LoginType,
+            profileImageUrl: String? = null
+        ): Member {
+            require(name.isNotBlank()) {
+                throw GeneralException(ErrorStatus.NAME_CAN_NOT_NULL_OR_EMPTY)
+            }
+            return Member(id, email, name, loginType, profileImageUrl)
+        }
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/member/domain/Member.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/domain/Member.kt
@@ -5,7 +5,7 @@ import kr.spot.common.api.status.ErrorStatus
 import kr.spot.common.exception.GeneralException
 import kr.spot.core.member.domain.enums.LoginType
 import kr.spot.core.member.domain.vo.Email
-import kr.spot.core.shared.domain.BaseEntity
+import kr.spot.core.global.domain.BaseEntity
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 

--- a/core/src/main/kotlin/kr/spot/core/member/domain/Member.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/domain/Member.kt
@@ -1,11 +1,18 @@
 package kr.spot.core.member.domain
 
-import jakarta.persistence.*
+import jakarta.persistence.AttributeOverride
+import jakarta.persistence.Column
+import jakarta.persistence.Embedded
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
 import kr.spot.common.api.status.ErrorStatus
 import kr.spot.common.exception.GeneralException
+import kr.spot.core.global.domain.BaseEntity
 import kr.spot.core.member.domain.enums.LoginType
 import kr.spot.core.member.domain.vo.Email
-import kr.spot.core.global.domain.BaseEntity
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 
@@ -16,22 +23,17 @@ import org.hibernate.annotations.SQLRestriction
 class Member private constructor(
     @Id
     val id: Long,
-
     @Embedded
     @AttributeOverride(name = "value", column = Column(name = "email", nullable = false, unique = true))
     val email: Email,
-
     @Column(nullable = false)
     var name: String,
-
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     val loginType: LoginType,
-
     @Column
     var profileImageUrl: String? = null
 ) : BaseEntity() {
-
     fun updateName(newName: String) {
         require(newName.isNotBlank()) {
             throw GeneralException(ErrorStatus.NAME_CAN_NOT_NULL_OR_EMPTY)

--- a/core/src/main/kotlin/kr/spot/core/member/domain/PreferredCategory.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/domain/PreferredCategory.kt
@@ -3,7 +3,7 @@ package kr.spot.core.member.domain
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import kr.spot.core.shared.domain.BaseEntity
+import kr.spot.core.global.domain.BaseEntity
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 

--- a/core/src/main/kotlin/kr/spot/core/member/domain/PreferredCategory.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/domain/PreferredCategory.kt
@@ -14,15 +14,14 @@ import org.hibernate.annotations.SQLRestriction
 class PreferredCategory private constructor(
     @Id
     val id: Long,
-
     val memberId: Long,
-
     val category: String
 ) : BaseEntity() {
-
     companion object {
-        fun of(id: Long, memberId: Long, category: String): PreferredCategory {
-            return PreferredCategory(id, memberId, category)
-        }
+        fun of(
+            id: Long,
+            memberId: Long,
+            category: String
+        ): PreferredCategory = PreferredCategory(id, memberId, category)
     }
 }

--- a/core/src/main/kotlin/kr/spot/core/member/domain/PreferredCategory.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/domain/PreferredCategory.kt
@@ -1,0 +1,28 @@
+package kr.spot.core.member.domain
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import kr.spot.core.shared.domain.BaseEntity
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
+
+@Entity
+@Table(name = "preferred_category")
+@SQLDelete(sql = "UPDATE preferred_category SET status = 'INACTIVE' WHERE id = ?")
+@SQLRestriction("status = 'ACTIVE'")
+class PreferredCategory private constructor(
+    @Id
+    val id: Long,
+
+    val memberId: Long,
+
+    val category: String
+) : BaseEntity() {
+
+    companion object {
+        fun of(id: Long, memberId: Long, category: String): PreferredCategory {
+            return PreferredCategory(id, memberId, category)
+        }
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/member/domain/PreferredRegion.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/domain/PreferredRegion.kt
@@ -3,7 +3,7 @@ package kr.spot.core.member.domain
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import kr.spot.core.shared.domain.BaseEntity
+import kr.spot.core.global.domain.BaseEntity
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 

--- a/core/src/main/kotlin/kr/spot/core/member/domain/PreferredRegion.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/domain/PreferredRegion.kt
@@ -1,0 +1,28 @@
+package kr.spot.core.member.domain
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import kr.spot.core.shared.domain.BaseEntity
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
+
+@Entity
+@Table(name = "preferred_region")
+@SQLDelete(sql = "UPDATE preferred_region SET status = 'INACTIVE' WHERE id = ?")
+@SQLRestriction("status = 'ACTIVE'")
+class PreferredRegion private constructor(
+    @Id
+    val id: Long,
+
+    val memberId: Long,
+
+    val regionCode: String
+) : BaseEntity() {
+
+    companion object {
+        fun of(id: Long, memberId: Long, regionCode: String): PreferredRegion {
+            return PreferredRegion(id, memberId, regionCode)
+        }
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/member/domain/PreferredRegion.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/domain/PreferredRegion.kt
@@ -14,15 +14,14 @@ import org.hibernate.annotations.SQLRestriction
 class PreferredRegion private constructor(
     @Id
     val id: Long,
-
     val memberId: Long,
-
     val regionCode: String
 ) : BaseEntity() {
-
     companion object {
-        fun of(id: Long, memberId: Long, regionCode: String): PreferredRegion {
-            return PreferredRegion(id, memberId, regionCode)
-        }
+        fun of(
+            id: Long,
+            memberId: Long,
+            regionCode: String
+        ): PreferredRegion = PreferredRegion(id, memberId, regionCode)
     }
 }

--- a/core/src/main/kotlin/kr/spot/core/member/domain/enums/LoginType.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/domain/enums/LoginType.kt
@@ -1,0 +1,6 @@
+package kr.spot.core.member.domain.enums
+
+enum class LoginType {
+    NAVER,
+    KAKAO
+}

--- a/core/src/main/kotlin/kr/spot/core/member/domain/vo/Email.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/domain/vo/Email.kt
@@ -1,0 +1,24 @@
+package kr.spot.core.member.domain.vo
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import kr.spot.common.api.status.ErrorStatus
+import kr.spot.common.exception.GeneralException
+
+@Embeddable
+data class Email(
+    @Column(nullable = false, name = "email")
+    val value: String
+) {
+    init {
+        require(value.isNotBlank() && EMAIL_PATTERN.matches(value)) {
+            throw GeneralException(ErrorStatus.INVALID_EMAIL_FORMAT)
+        }
+    }
+
+    companion object {
+        private val EMAIL_PATTERN = Regex("^[\\w-.]+@([\\w-]+\\.)+[\\w-]{2,4}$")
+
+        fun of(value: String): Email = Email(value)
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/member/infrastructure/MemberRepository.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/infrastructure/MemberRepository.kt
@@ -6,20 +6,25 @@ import kr.spot.core.member.domain.Member
 import kr.spot.core.member.domain.enums.LoginType
 import kr.spot.core.member.domain.vo.Email
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Modifying
-import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
 
 interface MemberRepository : JpaRepository<Member, Long> {
+    fun existsByEmailAndLoginType(
+        email: Email,
+        loginType: LoginType
+    ): Boolean
 
-    fun existsByEmailAndLoginType(email: Email, loginType: LoginType): Boolean
-
-    fun findByEmailAndLoginType(email: Email, loginType: LoginType): Member?
+    fun findByEmailAndLoginType(
+        email: Email,
+        loginType: LoginType
+    ): Member?
 }
 
 fun MemberRepository.findByIdOrThrow(id: Long): Member =
     findById(id).orElseThrow { GeneralException(ErrorStatus.MEMBER_NOT_FOUND) }
 
-fun MemberRepository.findByEmailAndLoginTypeOrThrow(email: Email, loginType: LoginType): Member =
+fun MemberRepository.findByEmailAndLoginTypeOrThrow(
+    email: Email,
+    loginType: LoginType
+): Member =
     findByEmailAndLoginType(email, loginType)
         ?: throw GeneralException(ErrorStatus.MEMBER_NOT_FOUND)

--- a/core/src/main/kotlin/kr/spot/core/member/infrastructure/MemberRepository.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/infrastructure/MemberRepository.kt
@@ -1,0 +1,25 @@
+package kr.spot.core.member.infrastructure
+
+import kr.spot.common.api.status.ErrorStatus
+import kr.spot.common.exception.GeneralException
+import kr.spot.core.member.domain.Member
+import kr.spot.core.member.domain.enums.LoginType
+import kr.spot.core.member.domain.vo.Email
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface MemberRepository : JpaRepository<Member, Long> {
+
+    fun existsByEmailAndLoginType(email: Email, loginType: LoginType): Boolean
+
+    fun findByEmailAndLoginType(email: Email, loginType: LoginType): Member?
+}
+
+fun MemberRepository.findByIdOrThrow(id: Long): Member =
+    findById(id).orElseThrow { GeneralException(ErrorStatus.MEMBER_NOT_FOUND) }
+
+fun MemberRepository.findByEmailAndLoginTypeOrThrow(email: Email, loginType: LoginType): Member =
+    findByEmailAndLoginType(email, loginType)
+        ?: throw GeneralException(ErrorStatus.MEMBER_NOT_FOUND)

--- a/core/src/main/kotlin/kr/spot/core/member/infrastructure/PreferredCategoryRepository.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/infrastructure/PreferredCategoryRepository.kt
@@ -4,7 +4,6 @@ import kr.spot.core.member.domain.PreferredCategory
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface PreferredCategoryRepository : JpaRepository<PreferredCategory, Long> {
-
     fun findAllByMemberId(memberId: Long): List<PreferredCategory>
 
     fun deleteAllByMemberId(memberId: Long)

--- a/core/src/main/kotlin/kr/spot/core/member/infrastructure/PreferredCategoryRepository.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/infrastructure/PreferredCategoryRepository.kt
@@ -1,0 +1,11 @@
+package kr.spot.core.member.infrastructure
+
+import kr.spot.core.member.domain.PreferredCategory
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PreferredCategoryRepository : JpaRepository<PreferredCategory, Long> {
+
+    fun findAllByMemberId(memberId: Long): List<PreferredCategory>
+
+    fun deleteAllByMemberId(memberId: Long)
+}

--- a/core/src/main/kotlin/kr/spot/core/member/infrastructure/PreferredRegionRepository.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/infrastructure/PreferredRegionRepository.kt
@@ -4,7 +4,6 @@ import kr.spot.core.member.domain.PreferredRegion
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface PreferredRegionRepository : JpaRepository<PreferredRegion, Long> {
-
     fun findAllByMemberId(memberId: Long): List<PreferredRegion>
 
     fun deleteAllByMemberId(memberId: Long)

--- a/core/src/main/kotlin/kr/spot/core/member/infrastructure/PreferredRegionRepository.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/infrastructure/PreferredRegionRepository.kt
@@ -1,0 +1,11 @@
+package kr.spot.core.member.infrastructure
+
+import kr.spot.core.member.domain.PreferredRegion
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PreferredRegionRepository : JpaRepository<PreferredRegion, Long> {
+
+    fun findAllByMemberId(memberId: Long): List<PreferredRegion>
+
+    fun deleteAllByMemberId(memberId: Long)
+}

--- a/core/src/main/kotlin/kr/spot/core/member/presentation/MemberController.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/presentation/MemberController.kt
@@ -6,9 +6,7 @@ import kr.spot.common.api.ApiResponse
 import kr.spot.common.api.status.SuccessStatus
 import kr.spot.core.member.application.MemberCommandService
 import kr.spot.core.member.application.MemberQueryService
-import kr.spot.core.member.presentation.dto.request.RegisterPreferredCategoryRequest
-import kr.spot.core.member.presentation.dto.request.RegisterPreferredRegionRequest
-import kr.spot.core.member.presentation.dto.request.UpdateMemberNameRequest
+import kr.spot.core.member.presentation.dto.request.*
 import kr.spot.core.member.presentation.dto.response.*
 import org.springframework.web.bind.annotation.*
 
@@ -24,7 +22,7 @@ class MemberController(
     @Operation(summary = "회원 이름 조회")
     @GetMapping("/name")
     fun getMemberName(
-        @RequestAttribute("memberId") memberId: Long  // TODO: @CurrentMember 어노테이션으로 교체
+        @RequestAttribute("memberId") memberId: Long
     ): ApiResponse<GetMemberNameResponse> {
         val name = memberQueryService.getMemberName(memberId)
         return ApiResponse.ok(GetMemberNameResponse.from(name))
@@ -96,5 +94,16 @@ class MemberController(
     ): ApiResponse<Unit> {
         memberCommandService.withdraw(memberId)
         return ApiResponse.ok()
+    }
+
+    // ==================== Test ====================
+
+    @Operation(summary = "[테스트용] 회원 생성", description = "개발/테스트 환경에서 사용하는 회원 생성 API")
+    @PostMapping("/test")
+    fun createTestMember(
+        @RequestBody request: CreateTestMemberRequest
+    ): ApiResponse<CreateTestMemberResponse> {
+        val memberId = memberCommandService.createTestMember(request.name, request.email)
+        return ApiResponse.created(CreateTestMemberResponse(memberId))
     }
 }

--- a/core/src/main/kotlin/kr/spot/core/member/presentation/MemberController.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/presentation/MemberController.kt
@@ -6,9 +6,22 @@ import kr.spot.common.api.ApiResponse
 import kr.spot.common.api.status.SuccessStatus
 import kr.spot.core.member.application.MemberCommandService
 import kr.spot.core.member.application.MemberQueryService
-import kr.spot.core.member.presentation.dto.request.*
-import kr.spot.core.member.presentation.dto.response.*
-import org.springframework.web.bind.annotation.*
+import kr.spot.core.member.presentation.dto.request.CreateTestMemberRequest
+import kr.spot.core.member.presentation.dto.request.RegisterPreferredCategoryRequest
+import kr.spot.core.member.presentation.dto.request.RegisterPreferredRegionRequest
+import kr.spot.core.member.presentation.dto.request.UpdateMemberNameRequest
+import kr.spot.core.member.presentation.dto.response.CreateTestMemberResponse
+import kr.spot.core.member.presentation.dto.response.GetMemberInfoResponse
+import kr.spot.core.member.presentation.dto.response.GetMemberNameResponse
+import kr.spot.core.member.presentation.dto.response.GetMemberPreferCategoryResponse
+import kr.spot.core.member.presentation.dto.response.GetMemberPreferRegionResponse
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestAttribute
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 
 @Tag(name = "회원")
 @RestController
@@ -61,7 +74,7 @@ class MemberController(
     @PostMapping("/prefer-categories")
     fun registerPreferCategories(
         @RequestBody request: RegisterPreferredCategoryRequest,
-        @RequestAttribute ("memberId") memberId: Long
+        @RequestAttribute("memberId") memberId: Long
     ): ApiResponse<Unit> {
         memberCommandService.registerPreferCategories(memberId, request.categories)
         return ApiResponse.success(SuccessStatus.NO_CONTENT)
@@ -71,7 +84,7 @@ class MemberController(
     @PostMapping("/prefer-regions")
     fun registerPreferRegions(
         @RequestBody request: RegisterPreferredRegionRequest,
-        @RequestAttribute ("memberId") memberId: Long
+        @RequestAttribute("memberId") memberId: Long
     ): ApiResponse<Unit> {
         memberCommandService.registerPreferRegions(memberId, request.regionCodes)
         return ApiResponse.success(SuccessStatus.NO_CONTENT)

--- a/core/src/main/kotlin/kr/spot/core/member/presentation/MemberController.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/presentation/MemberController.kt
@@ -1,0 +1,100 @@
+package kr.spot.core.member.presentation
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import kr.spot.common.api.ApiResponse
+import kr.spot.common.api.status.SuccessStatus
+import kr.spot.core.member.application.MemberCommandService
+import kr.spot.core.member.application.MemberQueryService
+import kr.spot.core.member.presentation.dto.request.RegisterPreferredCategoryRequest
+import kr.spot.core.member.presentation.dto.request.RegisterPreferredRegionRequest
+import kr.spot.core.member.presentation.dto.request.UpdateMemberNameRequest
+import kr.spot.core.member.presentation.dto.response.*
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "회원")
+@RestController
+@RequestMapping("/api/members")
+class MemberController(
+    private val memberCommandService: MemberCommandService,
+    private val memberQueryService: MemberQueryService
+) {
+    // ==================== Query ====================
+
+    @Operation(summary = "회원 이름 조회")
+    @GetMapping("/name")
+    fun getMemberName(
+        @RequestAttribute("memberId") memberId: Long  // TODO: @CurrentMember 어노테이션으로 교체
+    ): ApiResponse<GetMemberNameResponse> {
+        val name = memberQueryService.getMemberName(memberId)
+        return ApiResponse.ok(GetMemberNameResponse.from(name))
+    }
+
+    @Operation(summary = "회원 정보 조회")
+    @GetMapping("/info")
+    fun getMemberInfo(
+        @RequestAttribute("memberId") memberId: Long
+    ): ApiResponse<GetMemberInfoResponse> {
+        val member = memberQueryService.getMember(memberId)
+        return ApiResponse.ok(GetMemberInfoResponse.from(member))
+    }
+
+    @Operation(summary = "선호 카테고리 조회")
+    @GetMapping("/prefer-categories")
+    fun getPreferCategories(
+        @RequestAttribute("memberId") memberId: Long
+    ): ApiResponse<GetMemberPreferCategoryResponse> {
+        val categories = memberQueryService.getPreferredCategories(memberId)
+        return ApiResponse.ok(GetMemberPreferCategoryResponse.from(categories))
+    }
+
+    @Operation(summary = "선호 지역 조회")
+    @GetMapping("/prefer-regions")
+    fun getPreferRegions(
+        @RequestAttribute("memberId") memberId: Long
+    ): ApiResponse<GetMemberPreferRegionResponse> {
+        val regions = memberQueryService.getPreferredRegions(memberId)
+        return ApiResponse.ok(GetMemberPreferRegionResponse.from(regions))
+    }
+
+    // ==================== Command ====================
+
+    @Operation(summary = "회원 선호 카테고리 설정")
+    @PostMapping("/prefer-categories")
+    fun registerPreferCategories(
+        @RequestBody request: RegisterPreferredCategoryRequest,
+        @RequestAttribute ("memberId") memberId: Long
+    ): ApiResponse<Unit> {
+        memberCommandService.registerPreferCategories(memberId, request.categories)
+        return ApiResponse.success(SuccessStatus.NO_CONTENT)
+    }
+
+    @Operation(summary = "회원 선호 지역 설정")
+    @PostMapping("/prefer-regions")
+    fun registerPreferRegions(
+        @RequestBody request: RegisterPreferredRegionRequest,
+        @RequestAttribute ("memberId") memberId: Long
+    ): ApiResponse<Unit> {
+        memberCommandService.registerPreferRegions(memberId, request.regionCodes)
+        return ApiResponse.success(SuccessStatus.NO_CONTENT)
+    }
+
+    @Operation(summary = "회원 이름 수정")
+    @PostMapping("/name")
+    fun updateMemberName(
+        @RequestBody request: UpdateMemberNameRequest,
+        @RequestAttribute("memberId") memberId: Long
+    ): ApiResponse<Unit> {
+        memberCommandService.updateName(memberId, request.name)
+        return ApiResponse.success(SuccessStatus.NO_CONTENT)
+    }
+
+    @Operation(summary = "회원 탈퇴")
+    @DeleteMapping("/me")
+    fun withdraw(
+        @RequestAttribute("memberId") memberId: Long
+    ): ApiResponse<Unit> {
+        memberCommandService.withdraw(memberId)
+        return ApiResponse.ok()
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/member/presentation/dto/request/MemberRequest.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/presentation/dto/request/MemberRequest.kt
@@ -1,0 +1,13 @@
+package kr.spot.core.member.presentation.dto.request
+
+data class UpdateMemberNameRequest(
+    val name: String
+)
+
+data class RegisterPreferredCategoryRequest(
+    val categories: List<String>
+)
+
+data class RegisterPreferredRegionRequest(
+    val regionCodes: List<String>
+)

--- a/core/src/main/kotlin/kr/spot/core/member/presentation/dto/request/MemberRequest.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/presentation/dto/request/MemberRequest.kt
@@ -11,3 +11,8 @@ data class RegisterPreferredCategoryRequest(
 data class RegisterPreferredRegionRequest(
     val regionCodes: List<String>
 )
+
+data class CreateTestMemberRequest(
+    val name: String,
+    val email: String
+)

--- a/core/src/main/kotlin/kr/spot/core/member/presentation/dto/response/MemberResponse.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/presentation/dto/response/MemberResponse.kt
@@ -19,13 +19,14 @@ data class GetMemberInfoResponse(
     val email: String
 ) {
     companion object {
-        fun from(member: Member) = GetMemberInfoResponse(
-            memberId = member.id,
-            nickname = member.name,
-            profileImageUrl = member.profileImageUrl,
-            loginType = member.loginType,
-            email = member.email.value
-        )
+        fun from(member: Member) =
+            GetMemberInfoResponse(
+                memberId = member.id,
+                nickname = member.name,
+                profileImageUrl = member.profileImageUrl,
+                loginType = member.loginType,
+                email = member.email.value
+            )
     }
 }
 
@@ -34,10 +35,11 @@ data class GetMemberPreferCategoryResponse(
     val totalCount: Int
 ) {
     companion object {
-        fun from(categories: List<String>) = GetMemberPreferCategoryResponse(
-            categories = categories,
-            totalCount = categories.size
-        )
+        fun from(categories: List<String>) =
+            GetMemberPreferCategoryResponse(
+                categories = categories,
+                totalCount = categories.size
+            )
     }
 }
 
@@ -46,10 +48,11 @@ data class GetMemberPreferRegionResponse(
     val totalCount: Int
 ) {
     companion object {
-        fun from(regionCodes: List<String>) = GetMemberPreferRegionResponse(
-            regionCodes = regionCodes,
-            totalCount = regionCodes.size
-        )
+        fun from(regionCodes: List<String>) =
+            GetMemberPreferRegionResponse(
+                regionCodes = regionCodes,
+                totalCount = regionCodes.size
+            )
     }
 }
 

--- a/core/src/main/kotlin/kr/spot/core/member/presentation/dto/response/MemberResponse.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/presentation/dto/response/MemberResponse.kt
@@ -52,3 +52,7 @@ data class GetMemberPreferRegionResponse(
         )
     }
 }
+
+data class CreateTestMemberResponse(
+    val memberId: Long
+)

--- a/core/src/main/kotlin/kr/spot/core/member/presentation/dto/response/MemberResponse.kt
+++ b/core/src/main/kotlin/kr/spot/core/member/presentation/dto/response/MemberResponse.kt
@@ -1,0 +1,54 @@
+package kr.spot.core.member.presentation.dto.response
+
+import kr.spot.core.member.domain.Member
+import kr.spot.core.member.domain.enums.LoginType
+
+data class GetMemberNameResponse(
+    val name: String
+) {
+    companion object {
+        fun from(name: String) = GetMemberNameResponse(name)
+    }
+}
+
+data class GetMemberInfoResponse(
+    val memberId: Long,
+    val nickname: String,
+    val profileImageUrl: String?,
+    val loginType: LoginType,
+    val email: String
+) {
+    companion object {
+        fun from(member: Member) = GetMemberInfoResponse(
+            memberId = member.id,
+            nickname = member.name,
+            profileImageUrl = member.profileImageUrl,
+            loginType = member.loginType,
+            email = member.email.value
+        )
+    }
+}
+
+data class GetMemberPreferCategoryResponse(
+    val categories: List<String>,
+    val totalCount: Int
+) {
+    companion object {
+        fun from(categories: List<String>) = GetMemberPreferCategoryResponse(
+            categories = categories,
+            totalCount = categories.size
+        )
+    }
+}
+
+data class GetMemberPreferRegionResponse(
+    val regionCodes: List<String>,
+    val totalCount: Int
+) {
+    companion object {
+        fun from(regionCodes: List<String>) = GetMemberPreferRegionResponse(
+            regionCodes = regionCodes,
+            totalCount = regionCodes.size
+        )
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/post/application/CommentCommandService.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/application/CommentCommandService.kt
@@ -1,0 +1,81 @@
+package kr.spot.core.post.application
+
+import kr.spot.common.api.status.ErrorStatus
+import kr.spot.common.exception.GeneralException
+import kr.spot.common.id.IdGenerator
+import kr.spot.core.member.application.MemberQueryService
+import kr.spot.core.post.domain.Comment
+import kr.spot.core.post.domain.vo.WriterInfo
+import kr.spot.core.post.infrastructure.jpa.CommentRepository
+import kr.spot.core.post.infrastructure.jpa.getByIdOrThrow
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class CommentCommandService(
+    private val idGenerator: IdGenerator,
+    private val commentRepository: CommentRepository,
+    private val memberQueryService: MemberQueryService
+) {
+    /**
+     * 댓글 생성
+     */
+    fun createComment(
+        memberId: Long,
+        postId: Long,
+        content: String
+    ): Long {
+        val member = memberQueryService.getMember(memberId)
+        val writerInfo =
+            WriterInfo.of(
+                writerId = member.id,
+                writerNickname = member.name,
+                writerProfileImageUrl = member.profileImageUrl
+            )
+
+        val comment =
+            Comment.of(
+                id = idGenerator.nextId(),
+                postId = postId,
+                writerInfo = writerInfo,
+                content = content
+            )
+
+        return commentRepository.save(comment).id
+    }
+
+    /**
+     * 댓글 수정
+     */
+    fun updateComment(
+        memberId: Long,
+        commentId: Long,
+        content: String
+    ) {
+        val comment = commentRepository.getByIdOrThrow(commentId)
+        validateOwner(comment, memberId)
+        comment.update(content)
+    }
+
+    /**
+     * 댓글 삭제
+     */
+    fun deleteComment(
+        memberId: Long,
+        commentId: Long
+    ) {
+        val comment = commentRepository.getByIdOrThrow(commentId)
+        validateOwner(comment, memberId)
+        commentRepository.delete(comment)
+    }
+
+    private fun validateOwner(
+        comment: Comment,
+        memberId: Long
+    ) {
+        if (!comment.isOwner(memberId)) {
+            throw GeneralException(ErrorStatus.FORBIDDEN)
+        }
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/post/application/PostCommandService.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/application/PostCommandService.kt
@@ -1,0 +1,114 @@
+package kr.spot.core.post.application
+
+import kr.spot.common.api.status.ErrorStatus
+import kr.spot.common.exception.GeneralException
+import kr.spot.common.id.IdGenerator
+import kr.spot.core.member.application.MemberQueryService
+import kr.spot.core.post.domain.Post
+import kr.spot.core.post.domain.enums.PostType
+import kr.spot.core.post.domain.vo.PostStats
+import kr.spot.core.post.domain.vo.WriterInfo
+import kr.spot.core.post.infrastructure.jpa.PostLikeRepository
+import kr.spot.core.post.infrastructure.jpa.PostRepository
+import kr.spot.core.post.infrastructure.jpa.findByIdOrThrow
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class PostCommandService(
+    private val idGenerator: IdGenerator,
+    private val postRepository: PostRepository,
+    private val postLikeRepository: PostLikeRepository,
+    private val memberQueryService: MemberQueryService
+) {
+    /**
+     * 게시글 생성
+     */
+    fun createPost(
+        memberId: Long,
+        title: String,
+        content: String,
+        postType: PostType
+    ): Long {
+        val member = memberQueryService.getMember(memberId)
+        val writerInfo =
+            WriterInfo.of(
+                writerId = member.id,
+                writerNickname = member.name,
+                writerProfileImageUrl = member.profileImageUrl
+            )
+
+        val post =
+            Post.of(
+                id = idGenerator.nextId(),
+                writerInfo = writerInfo,
+                title = title,
+                content = content,
+                postType = postType,
+                postStats = PostStats.of(views = 0, likes = 0, comments = 0)
+            )
+
+        return postRepository.save(post).id
+    }
+
+    /**
+     * 게시글 수정
+     */
+    fun updatePost(
+        memberId: Long,
+        postId: Long,
+        title: String,
+        content: String,
+        postType: PostType
+    ) {
+        val post = postRepository.findByIdOrThrow(postId)
+        validateOwner(post, memberId)
+        post.update(title, content, postType)
+    }
+
+    /**
+     * 게시글 삭제
+     */
+    fun deletePost(
+        memberId: Long,
+        postId: Long
+    ) {
+        val post = postRepository.findByIdOrThrow(postId)
+        validateOwner(post, memberId)
+        postRepository.delete(post)
+    }
+
+    /**
+     * 게시글 좋아요
+     */
+    fun likePost(
+        memberId: Long,
+        postId: Long
+    ) {
+        postLikeRepository.savePostLike(
+            id = idGenerator.nextId(),
+            postId = postId,
+            memberId = memberId
+        )
+    }
+
+    /**
+     * 게시글 좋아요 취소
+     */
+    fun unlikePost(
+        memberId: Long,
+        postId: Long
+    ) {
+        postLikeRepository.hardDelete(postId = postId, memberId = memberId)
+    }
+
+    private fun validateOwner(
+        post: Post,
+        memberId: Long
+    ) {
+        if (!post.isOwner(memberId)) {
+            throw GeneralException(ErrorStatus.FORBIDDEN)
+        }
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/post/application/PostQueryService.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/application/PostQueryService.kt
@@ -1,0 +1,59 @@
+package kr.spot.core.post.application
+
+import kr.spot.core.post.application.mapper.PostMapper
+import kr.spot.core.post.domain.enums.PostType
+import kr.spot.core.post.infrastructure.jpa.CommentRepository
+import kr.spot.core.post.infrastructure.jpa.PostLikeRepository
+import kr.spot.core.post.infrastructure.jpa.PostRepository
+import kr.spot.core.post.infrastructure.jpa.findByIdOrThrow
+import kr.spot.core.post.presentation.query.dto.response.PostDetailResponse
+import kr.spot.core.post.presentation.query.dto.response.PostListResponse
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class PostQueryService(
+    private val postRepository: PostRepository,
+    private val commentRepository: CommentRepository,
+    private val postLikeRepository: PostLikeRepository,
+    private val postMapper: PostMapper
+) {
+    /**
+     * 게시글 상세 조회
+     */
+    fun getPostDetail(
+        postId: Long,
+        memberId: Long?
+    ): PostDetailResponse {
+        val post = postRepository.findByIdOrThrow(postId)
+        val comments = commentRepository.getCommentsByPostId(postId)
+        val isLiked = memberId?.let { postLikeRepository.existsByPostIdAndMemberId(postId, it) } ?: false
+        val isOwner = memberId?.let { post.isOwner(it) } ?: false
+
+        return postMapper.toDetailResponse(post, comments, isLiked, isOwner)
+    }
+
+    /**
+     * 게시글 목록 조회 (커서 기반 페이징)
+     */
+    fun getPostList(
+        cursor: Long?,
+        size: Int,
+        postType: PostType?,
+        memberId: Long?
+    ): PostListResponse {
+        val pageable = PageRequest.of(0, size + 1)
+        val posts = postRepository.findPostsWithCursor(cursor, postType, pageable)
+
+        val hasNext = posts.size > size
+        val resultPosts = if (hasNext) posts.dropLast(1) else posts
+        val nextCursor = if (hasNext) resultPosts.lastOrNull()?.id else null
+
+        val postIds = resultPosts.map { it.id }
+        val likedPostIds = memberId?.let { postLikeRepository.findLikedPostIds(it, postIds) }?.toSet() ?: emptySet()
+
+        return postMapper.toListResponse(resultPosts, likedPostIds, memberId, hasNext, nextCursor)
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/post/application/mapper/PostMapper.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/application/mapper/PostMapper.kt
@@ -1,0 +1,90 @@
+package kr.spot.core.post.application.mapper
+
+import kr.spot.core.post.domain.Comment
+import kr.spot.core.post.domain.Post
+import kr.spot.core.post.presentation.query.dto.response.PostDetailResponse
+import kr.spot.core.post.presentation.query.dto.response.PostDetailResponse.CommentResponse
+import kr.spot.core.post.presentation.query.dto.response.PostDetailResponse.PostStatsResponse
+import kr.spot.core.post.presentation.query.dto.response.PostDetailResponse.WriterInfoResponse
+import kr.spot.core.post.presentation.query.dto.response.PostListResponse
+import org.springframework.stereotype.Component
+
+@Component
+class PostMapper {
+    fun toDetailResponse(
+        post: Post,
+        comments: List<Comment>,
+        isLiked: Boolean,
+        isOwner: Boolean
+    ): PostDetailResponse =
+        PostDetailResponse(
+            postId = post.id,
+            title = post.title,
+            content = post.content,
+            imageUrl = null,
+            postType = post.postType,
+            isLiked = isLiked,
+            isOwner = isOwner,
+            writer = toWriterInfoResponse(post),
+            stats = toPostStatsResponse(post),
+            createdAt = post.createdAt!!,
+            comments = comments.map { toCommentResponse(it) },
+            commentCount = comments.size
+        )
+
+    fun toListResponse(
+        posts: List<Post>,
+        likedPostIds: Set<Long>,
+        memberId: Long?,
+        hasNext: Boolean,
+        nextCursor: Long?
+    ): PostListResponse =
+        PostListResponse(
+            posts =
+                posts.map { post ->
+                    PostListResponse.PostList.of(
+                        postId = post.id,
+                        title = post.title,
+                        content = post.content,
+                        postType = post.postType,
+                        stats =
+                            PostListResponse.PostStatsResponse.of(
+                                likeCount = post.postStats.likes,
+                                commentCount = post.postStats.comments,
+                                viewCount = post.postStats.views
+                            ),
+                        createdAt = post.createdAt!!,
+                        isLiked = memberId?.let { post.id in likedPostIds }
+                    )
+                },
+            hasNext = hasNext,
+            nextCursor = nextCursor
+        )
+
+    private fun toWriterInfoResponse(post: Post): WriterInfoResponse =
+        WriterInfoResponse.of(
+            writerId = post.writerInfo.writerId,
+            nickname = post.writerInfo.writerNickname,
+            profileImageUrl = post.writerInfo.writerProfileImageUrl
+        )
+
+    private fun toPostStatsResponse(post: Post): PostStatsResponse =
+        PostStatsResponse.of(
+            likeCount = post.postStats.likes,
+            commentCount = post.postStats.comments,
+            viewCount = post.postStats.views
+        )
+
+    private fun toCommentResponse(comment: Comment): CommentResponse =
+        CommentResponse.of(
+            commentId = comment.id,
+            content = comment.content,
+            writer =
+                WriterInfoResponse.of(
+                    writerId = comment.writerInfo.writerId,
+                    nickname = comment.writerInfo.writerNickname,
+                    profileImageUrl = comment.writerInfo.writerProfileImageUrl
+                ),
+            createdAt = comment.createdAt!!
+        )
+}

--- a/core/src/main/kotlin/kr/spot/core/post/domain/Comment.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/domain/Comment.kt
@@ -1,0 +1,47 @@
+package kr.spot.core.post.domain
+
+import jakarta.persistence.Embedded
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import kr.spot.core.global.domain.BaseEntity
+import kr.spot.core.post.domain.vo.WriterInfo
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
+
+@Entity
+@Table(name = "comment")
+@SQLDelete(sql = "UPDATE comment SET status = 'INACTIVE' WHERE id = ?")
+@SQLRestriction("status = 'ACTIVE'")
+class Comment private constructor(
+    @Id
+    val id: Long,
+    val postId: Long,
+    @Embedded
+    val writerInfo: WriterInfo,
+    content: String
+) : BaseEntity() {
+    var content: String = content
+        private set
+
+    fun update(content: String) {
+        this.content = content
+    }
+
+    fun isOwner(memberId: Long): Boolean = writerInfo.writerId == memberId
+
+    companion object {
+        fun of(
+            id: Long,
+            postId: Long,
+            writerInfo: WriterInfo,
+            content: String
+        ): Comment =
+            Comment(
+                id,
+                postId,
+                writerInfo,
+                content
+            )
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/post/domain/Post.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/domain/Post.kt
@@ -1,0 +1,68 @@
+package kr.spot.core.post.domain
+
+import jakarta.persistence.Embedded
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import kr.spot.core.global.domain.BaseEntity
+import kr.spot.core.post.domain.enums.PostType
+import kr.spot.core.post.domain.vo.PostStats
+import kr.spot.core.post.domain.vo.WriterInfo
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
+
+@Entity
+@Table(name = "post")
+@SQLDelete(sql = "UPDATE post SET status = 'INACTIVE' WHERE id = ?")
+@SQLRestriction("status = 'ACTIVE'")
+class Post private constructor(
+    @Id
+    val id: Long,
+    @Embedded
+    val writerInfo: WriterInfo,
+    title: String,
+    content: String,
+    postType: PostType,
+    @Embedded
+    val postStats: PostStats
+) : BaseEntity() {
+    var title: String = title
+        private set
+
+    var content: String = content
+        private set
+
+    var postType: PostType = postType
+        private set
+
+    fun update(
+        title: String,
+        content: String,
+        postType: PostType
+    ) {
+        this.title = title
+        this.content = content
+        this.postType = postType
+    }
+
+    fun isOwner(memberId: Long): Boolean = writerInfo.writerId == memberId
+
+    companion object {
+        fun of(
+            id: Long,
+            writerInfo: WriterInfo,
+            title: String,
+            content: String,
+            postType: PostType,
+            postStats: PostStats
+        ): Post =
+            Post(
+                id,
+                writerInfo,
+                title,
+                content,
+                postType,
+                postStats
+            )
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/post/domain/association/PostLike.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/domain/association/PostLike.kt
@@ -1,0 +1,40 @@
+package kr.spot.core.post.domain.association
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import kr.spot.core.global.domain.BaseEntity
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
+
+@Entity
+@Table(
+    name = "post_like",
+    uniqueConstraints = [
+        jakarta.persistence.UniqueConstraint(
+            name = "uk_post_like_post_id_member_id",
+            columnNames = ["postId", "memberId"]
+        )
+    ]
+)
+@SQLDelete(sql = "UPDATE post_like SET status = 'INACTIVE' WHERE id = ?")
+@SQLRestriction("status = 'ACTIVE'")
+class PostLike private constructor(
+    @Id
+    val id: Long,
+    val postId: Long,
+    val memberId: Long
+) : BaseEntity() {
+    companion object {
+        fun of(
+            id: Long,
+            postId: Long,
+            memberId: Long
+        ): PostLike =
+            PostLike(
+                id,
+                postId,
+                memberId
+            )
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/post/domain/enums/PostType.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/domain/enums/PostType.kt
@@ -1,0 +1,9 @@
+package kr.spot.core.post.domain.enums
+
+enum class PostType {
+    PASS_EXPERIENCE, // 합격후기
+    INFORMATION_SHARING, // 정보공유
+    COUNSELING, // 고민상담
+    JOB_TALK, // 취준토크
+    FREE_TALK // 자유토크
+}

--- a/core/src/main/kotlin/kr/spot/core/post/domain/vo/PostStats.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/domain/vo/PostStats.kt
@@ -1,0 +1,23 @@
+package kr.spot.core.post.domain.vo
+
+import jakarta.persistence.Embeddable
+
+@Embeddable
+class PostStats(
+    val views: Long,
+    val likes: Long,
+    val comments: Long
+) {
+    companion object {
+        fun of(
+            views: Long,
+            likes: Long,
+            comments: Long
+        ): PostStats =
+            PostStats(
+                views,
+                likes,
+                comments
+            )
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/post/domain/vo/WriterInfo.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/domain/vo/WriterInfo.kt
@@ -1,0 +1,23 @@
+package kr.spot.core.post.domain.vo
+
+import jakarta.persistence.Embeddable
+
+@Embeddable
+class WriterInfo(
+    val writerId: Long,
+    val writerNickname: String,
+    val writerProfileImageUrl: String?
+) {
+    companion object {
+        fun of(
+            writerId: Long,
+            writerNickname: String,
+            writerProfileImageUrl: String?
+        ): WriterInfo =
+            WriterInfo(
+                writerId,
+                writerNickname,
+                writerProfileImageUrl
+            )
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/post/infrastructure/jpa/CommentRepository.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/infrastructure/jpa/CommentRepository.kt
@@ -1,0 +1,60 @@
+package kr.spot.core.post.infrastructure.jpa
+
+import kr.spot.common.api.status.ErrorStatus
+import kr.spot.common.exception.GeneralException
+import kr.spot.core.post.domain.Comment
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface CommentRepository : JpaRepository<Comment, Long> {
+    @Query(
+        "select c from Comment c " +
+            "where c.postId = :postId and c.status = 'ACTIVE' " +
+            "order by c.createdAt asc"
+    )
+    fun getCommentsByPostId(
+        @Param("postId") postId: Long
+    ): List<Comment>
+
+    fun deleteByWriterInfoWriterId(writerId: Long)
+
+    @Modifying
+    @Query(
+        """
+        update Comment c
+           set c.content = :content,
+               c.updatedAt = CURRENT_TIMESTAMP
+         where c.id = :commentId
+           and c.writerInfo.writerId = :writerId
+           and c.status = 'ACTIVE'
+    """
+    )
+    fun updateComment(
+        @Param("commentId") commentId: Long,
+        @Param("content") content: String,
+        @Param("writerId") writerId: Long
+    ): Int
+
+    @Modifying
+    @Query(
+        """
+        update Comment c
+           set c.status = 'INACTIVE',
+               c.updatedAt = CURRENT_TIMESTAMP
+         where c.id = :commentId
+           and c.writerInfo.writerId = :writerId
+           and c.status = 'ACTIVE'
+    """
+    )
+    fun deleteComment(
+        @Param("commentId") commentId: Long,
+        @Param("writerId") writerId: Long
+    ): Int
+}
+
+fun CommentRepository.getByIdOrThrow(id: Long): Comment =
+    findById(id).orElseThrow {
+        GeneralException(ErrorStatus.COMMENT_NOT_FOUND)
+    }

--- a/core/src/main/kotlin/kr/spot/core/post/infrastructure/jpa/PostLikeRepository.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/infrastructure/jpa/PostLikeRepository.kt
@@ -1,0 +1,59 @@
+package kr.spot.core.post.infrastructure.jpa
+
+import kr.spot.core.post.domain.association.PostLike
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface PostLikeRepository : JpaRepository<PostLike, Long> {
+    @Modifying
+    @Query(
+        value = """
+            INSERT IGNORE INTO post_like(
+                id, post_id, member_id, status, created_at, updated_at
+            )
+            VALUES (:id, :postId, :memberId, 'ACTIVE', NOW(), NOW())
+        """,
+        nativeQuery = true
+    )
+    fun savePostLike(
+        @Param("id") id: Long,
+        @Param("postId") postId: Long,
+        @Param("memberId") memberId: Long
+    ): Int
+
+    @Modifying
+    @Query(
+        value = """
+            DELETE FROM post_like
+             WHERE post_id = :postId
+               AND member_id = :memberId
+        """,
+        nativeQuery = true
+    )
+    fun hardDelete(
+        @Param("postId") postId: Long,
+        @Param("memberId") memberId: Long
+    ): Int
+
+    @Modifying
+    @Query(
+        value = "DELETE FROM post_like WHERE member_id = :memberId",
+        nativeQuery = true
+    )
+    fun deleteAllByMemberId(
+        @Param("memberId") memberId: Long
+    )
+
+    fun existsByPostIdAndMemberId(
+        postId: Long,
+        memberId: Long
+    ): Boolean
+
+    @Query("select pl.postId from PostLike pl where pl.memberId = :memberId and pl.postId in :postIds")
+    fun findLikedPostIds(
+        @Param("memberId") memberId: Long,
+        @Param("postIds") postIds: List<Long>
+    ): List<Long>
+}

--- a/core/src/main/kotlin/kr/spot/core/post/infrastructure/jpa/PostRepository.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/infrastructure/jpa/PostRepository.kt
@@ -1,0 +1,95 @@
+package kr.spot.core.post.infrastructure.jpa
+
+import kr.spot.common.api.status.ErrorStatus
+import kr.spot.common.exception.GeneralException
+import kr.spot.core.post.domain.Post
+import kr.spot.core.post.domain.enums.PostType
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface PostRepository : JpaRepository<Post, Long> {
+    fun findByIdAndStatus(
+        id: Long,
+        status: String = "ACTIVE"
+    ): Post?
+
+    @Modifying
+    @Query(
+        """
+            update Post p
+               set p.title = :title,
+                   p.content = :content,
+                   p.postType = :postType,
+                   p.updatedAt = CURRENT_TIMESTAMP
+             where p.id = :postId
+               and p.writerInfo.writerId = :writerId
+               and p.status = 'ACTIVE'
+        """
+    )
+    fun updatePost(
+        @Param("postId") postId: Long,
+        @Param("title") title: String,
+        @Param("content") content: String,
+        @Param("postType") postType: PostType,
+        @Param("writerId") writerId: Long
+    ): Int
+
+    @Modifying
+    @Query(
+        """
+            update Post p
+               set p.status = 'INACTIVE',
+                   p.updatedAt = CURRENT_TIMESTAMP
+             where p.id = :postId
+               and p.writerInfo.writerId = :writerId
+               and p.status = 'ACTIVE'
+        """
+    )
+    fun deletePost(
+        @Param("postId") postId: Long,
+        @Param("writerId") writerId: Long
+    ): Int
+
+    @Query("select p from Post p where p.id in :postIds and p.status = 'ACTIVE'")
+    fun getPostsByIds(
+        @Param("postIds") postIds: List<Long>
+    ): List<Post>
+
+    fun deleteByWriterInfoWriterId(writerId: Long)
+
+    @Query(
+        """
+        select p from Post p
+         where p.status = 'ACTIVE'
+           and (:postType is null or p.postType = :postType)
+           and (:cursor is null or p.id < :cursor)
+         order by p.id desc
+    """
+    )
+    fun findPostsWithCursor(
+        @Param("cursor") cursor: Long?,
+        @Param("postType") postType: PostType?,
+        pageable: org.springframework.data.domain.Pageable
+    ): List<Post>
+
+    @Modifying
+    @Query(
+        """
+        update Post p
+           set p.postStats.views = p.postStats.views + :delta,
+               p.updatedAt = CURRENT_TIMESTAMP
+         where p.id = :postId and p.status = 'ACTIVE'
+    """
+    )
+    fun increaseViewBy(
+        @Param("postId") postId: Long,
+        @Param("delta") delta: Long
+    ): Int
+}
+
+fun PostRepository.findByIdOrThrow(id: Long): Post =
+    findById(id).orElseThrow {
+        GeneralException(ErrorStatus.POST_NOT_FOUND)
+    }

--- a/core/src/main/kotlin/kr/spot/core/post/infrastructure/redis/PostViewFlushJob.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/infrastructure/redis/PostViewFlushJob.kt
@@ -1,0 +1,178 @@
+package kr.spot.core.post.infrastructure.redis
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.Cursor
+import org.springframework.data.redis.core.RedisCallback
+import org.springframework.data.redis.core.ScanOptions
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
+
+@Component
+class PostViewFlushJob(
+    private val redis: StringRedisTemplate,
+    private val postViewFlusher: PostViewFlusher
+) {
+    @Scheduled(cron = "0 * * * * *")
+    fun flush() {
+        if (!tryAcquireLock()) {
+            log.debug("다른 인스턴스에서 실행 중")
+            return
+        }
+
+        try {
+            executeBatch()
+        } finally {
+            releaseLock()
+        }
+    }
+
+    private fun executeBatch() {
+        log.info("PostViewFlushJob 시작")
+        val startTime = System.currentTimeMillis()
+
+        val result = processAllKeys()
+
+        val duration = System.currentTimeMillis() - startTime
+        log.info(
+            "PostViewFlushJob 완료: 성공 {}건, 실패 {}건, {}ms",
+            result.successCount,
+            result.failureCount,
+            duration
+        )
+    }
+
+    private fun processAllKeys(): BatchResult {
+        val result = BatchResult()
+
+        val options =
+            ScanOptions
+                .scanOptions()
+                .match(KEY_PATTERN)
+                .count(500)
+                .build()
+
+        redis.execute(
+            RedisCallback { connection ->
+                try {
+                    connection.scan(options).use { cursor: Cursor<ByteArray> ->
+                        while (cursor.hasNext()) {
+                            val keyBytes = cursor.next()
+                            processKey(keyBytes, result)
+                        }
+                    }
+                } catch (e: Exception) {
+                    log.error("SCAN 처리 중 오류", e)
+                }
+                null
+            }
+        )
+
+        return result
+    }
+
+    private fun processKey(
+        keyBytes: ByteArray,
+        result: BatchResult
+    ) {
+        val key = String(keyBytes, StandardCharsets.UTF_8)
+        var delta = 0L
+
+        try {
+            // 1. GETDEL - 원자적으로 값을 읽고 삭제
+            val valueStr = redis.opsForValue().getAndDelete(key) ?: return
+
+            // 2. 값 파싱 및 검증
+            delta = parseLong(valueStr)
+            if (delta <= 0) {
+                log.warn("유효하지 않은 값 무시: key={}, value={}", key, valueStr)
+                return
+            }
+
+            val postId = extractPostIdFromKey(key)
+            if (postId == null) {
+                log.error("postId 추출 실패, 값 손실: key={}, delta={}", key, delta)
+                return
+            }
+
+            // 3. DB 업데이트 (별도 트랜잭션)
+            postViewFlusher.flushPostViews(postId, delta)
+
+            result.recordSuccess()
+            log.debug("처리 완료: postId={}, delta={}", postId, delta)
+        } catch (e: Exception) {
+            result.recordFailure()
+            log.error("처리 실패: key={}", key, e)
+
+            // GETDEL 이후 실패 시 값 복구하여 다음 배치에서 재시도
+            if (delta > 0) {
+                restoreValue(key, delta)
+            }
+        }
+    }
+
+    private fun restoreValue(
+        key: String,
+        delta: Long
+    ) {
+        try {
+            redis.opsForValue().increment(key, delta)
+            log.warn("DB 반영 실패, Redis에 값 복구 완료: key={}, delta={}", key, delta)
+        } catch (e: Exception) {
+            log.error("복구 실패, 데이터 손실: key={}, delta={}", key, delta, e)
+        }
+    }
+
+    private fun tryAcquireLock(): Boolean {
+        val acquired =
+            redis
+                .opsForValue()
+                .setIfAbsent(LOCK_KEY, "1", 55, TimeUnit.SECONDS)
+        return acquired == true
+    }
+
+    private fun releaseLock() {
+        redis.delete(LOCK_KEY)
+    }
+
+    private fun parseLong(value: String): Long =
+        try {
+            value.toLong()
+        } catch (e: NumberFormatException) {
+            log.warn("Long 파싱 실패: {}", value)
+            0L
+        }
+
+    private fun extractPostIdFromKey(key: String): Long? =
+        try {
+            key.substring(KEY_PREFIX.length).toLong()
+        } catch (e: Exception) {
+            log.error("postId 추출 실패: {}", key, e)
+            null
+        }
+
+    private class BatchResult {
+        var successCount: Int = 0
+            private set
+        var failureCount: Int = 0
+            private set
+
+        fun recordSuccess() {
+            successCount++
+        }
+
+        fun recordFailure() {
+            failureCount++
+        }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(PostViewFlushJob::class.java)
+
+        private const val KEY_PREFIX = "view:post:"
+        private const val KEY_PATTERN = "$KEY_PREFIX*"
+        private const val LOCK_KEY = "lock:view-flush"
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/post/infrastructure/redis/PostViewFlusher.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/infrastructure/redis/PostViewFlusher.kt
@@ -1,0 +1,25 @@
+package kr.spot.core.post.infrastructure.redis
+
+import kr.spot.core.post.infrastructure.jpa.PostRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class PostViewFlusher(
+    private val postRepository: PostRepository
+) {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun flushPostViews(
+        postId: Long,
+        delta: Long
+    ) {
+        postRepository.increaseViewBy(postId, delta)
+        log.debug("게시글 조회수 DB 업데이트: postId={}, delta={}", postId, delta)
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(PostViewFlusher::class.java)
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/post/presentation/command/dto/CommentCommandController.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/presentation/command/dto/CommentCommandController.kt
@@ -1,0 +1,67 @@
+package kr.spot.core.post.presentation.command.dto
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import kr.spot.common.api.ApiResponse
+import kr.spot.common.api.status.SuccessStatus
+import kr.spot.core.post.application.CommentCommandService
+import kr.spot.core.post.presentation.command.dto.request.ManageCommentRequest
+import kr.spot.core.post.presentation.command.dto.response.CreateCommentResponse
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestAttribute
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "게시글 - 댓글")
+@RestController
+@RequestMapping("/api/posts")
+class CommentCommandController(
+    private val commentCommandService: CommentCommandService
+) {
+    @Operation(summary = "댓글 생성")
+    @PostMapping("{postId}/comments")
+    fun createComment(
+        @RequestBody request: ManageCommentRequest,
+        @PathVariable postId: Long,
+        @RequestAttribute("memberId") memberId: Long
+    ): ApiResponse<CreateCommentResponse> {
+        val commentId =
+            commentCommandService.createComment(
+                memberId = memberId,
+                postId = postId,
+                content = request.content
+            )
+        return ApiResponse.created(CreateCommentResponse(commentId))
+    }
+
+    @Operation(summary = "댓글 수정")
+    @PutMapping("/{postId}/comments/{commentId}")
+    fun updateComment(
+        @RequestBody request: ManageCommentRequest,
+        @PathVariable postId: Long,
+        @PathVariable commentId: Long,
+        @RequestAttribute("memberId") memberId: Long
+    ): ApiResponse<Unit> {
+        commentCommandService.updateComment(
+            memberId = memberId,
+            commentId = commentId,
+            content = request.content
+        )
+        return ApiResponse.success(SuccessStatus.NO_CONTENT)
+    }
+
+    @Operation(summary = "댓글 삭제")
+    @DeleteMapping("/{postId}/comments/{commentId}")
+    fun deleteComment(
+        @PathVariable postId: Long,
+        @PathVariable commentId: Long,
+        @RequestAttribute("memberId") memberId: Long
+    ): ApiResponse<Unit> {
+        commentCommandService.deleteComment(memberId = memberId, commentId = commentId)
+        return ApiResponse.success(SuccessStatus.NO_CONTENT)
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/post/presentation/command/dto/PostCommandController.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/presentation/command/dto/PostCommandController.kt
@@ -1,0 +1,87 @@
+package kr.spot.core.post.presentation.command.dto
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import kr.spot.common.api.ApiResponse
+import kr.spot.common.api.status.SuccessStatus
+import kr.spot.core.post.application.PostCommandService
+import kr.spot.core.post.presentation.command.dto.request.ManagePostRequest
+import kr.spot.core.post.presentation.command.dto.response.CreatePostResponse
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestAttribute
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "게시글")
+@RestController
+@RequestMapping("/api/posts")
+class PostCommandController(
+    private val postCommandService: PostCommandService
+) {
+    @Operation(summary = "게시글 생성")
+    @PostMapping
+    fun createPost(
+        @RequestBody request: ManagePostRequest,
+        @RequestAttribute("memberId") memberId: Long
+    ): ApiResponse<CreatePostResponse> {
+        val postId =
+            postCommandService.createPost(
+                memberId = memberId,
+                title = request.title,
+                content = request.content,
+                postType = request.postType
+            )
+        return ApiResponse.created(CreatePostResponse(postId))
+    }
+
+    @Operation(summary = "게시글 수정")
+    @PutMapping("/{postId}")
+    fun updatePost(
+        @RequestBody request: ManagePostRequest,
+        @PathVariable postId: Long,
+        @RequestAttribute("memberId") memberId: Long
+    ): ApiResponse<Unit> {
+        postCommandService.updatePost(
+            memberId = memberId,
+            postId = postId,
+            title = request.title,
+            content = request.content,
+            postType = request.postType
+        )
+        return ApiResponse.success(SuccessStatus.NO_CONTENT)
+    }
+
+    @Operation(summary = "게시글 삭제")
+    @DeleteMapping("/{postId}")
+    fun deletePost(
+        @PathVariable postId: Long,
+        @RequestAttribute("memberId") memberId: Long
+    ): ApiResponse<Unit> {
+        postCommandService.deletePost(memberId = memberId, postId = postId)
+        return ApiResponse.success(SuccessStatus.NO_CONTENT)
+    }
+
+    @Operation(summary = "게시글 좋아요")
+    @PostMapping("/{postId}/like")
+    fun likePost(
+        @PathVariable postId: Long,
+        @RequestAttribute("memberId") memberId: Long
+    ): ApiResponse<Unit> {
+        postCommandService.likePost(memberId = memberId, postId = postId)
+        return ApiResponse.success(SuccessStatus.NO_CONTENT)
+    }
+
+    @Operation(summary = "게시글 좋아요 취소")
+    @DeleteMapping("/{postId}/like")
+    fun unlikePost(
+        @PathVariable postId: Long,
+        @RequestAttribute("memberId") memberId: Long
+    ): ApiResponse<Unit> {
+        postCommandService.unlikePost(memberId = memberId, postId = postId)
+        return ApiResponse.success(SuccessStatus.NO_CONTENT)
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/post/presentation/command/dto/request/ManageCommentRequest.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/presentation/command/dto/request/ManageCommentRequest.kt
@@ -1,0 +1,5 @@
+package kr.spot.core.post.presentation.command.dto.request
+
+data class ManageCommentRequest(
+    val content: String
+)

--- a/core/src/main/kotlin/kr/spot/core/post/presentation/command/dto/request/ManagePostRequest.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/presentation/command/dto/request/ManagePostRequest.kt
@@ -1,0 +1,9 @@
+package kr.spot.core.post.presentation.command.dto.request
+
+import kr.spot.core.post.domain.enums.PostType
+
+data class ManagePostRequest(
+    val title: String,
+    val content: String,
+    val postType: PostType
+)

--- a/core/src/main/kotlin/kr/spot/core/post/presentation/command/dto/response/CreateCommentResponse.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/presentation/command/dto/response/CreateCommentResponse.kt
@@ -1,0 +1,5 @@
+package kr.spot.core.post.presentation.command.dto.response
+
+data class CreateCommentResponse(
+    val commentId: Long
+)

--- a/core/src/main/kotlin/kr/spot/core/post/presentation/command/dto/response/CreatePostResponse.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/presentation/command/dto/response/CreatePostResponse.kt
@@ -1,0 +1,5 @@
+package kr.spot.core.post.presentation.command.dto.response
+
+data class CreatePostResponse(
+    val postId: Long
+)

--- a/core/src/main/kotlin/kr/spot/core/post/presentation/query/PostQueryController.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/presentation/query/PostQueryController.kt
@@ -1,0 +1,44 @@
+package kr.spot.core.post.presentation.query
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import kr.spot.common.api.ApiResponse
+import kr.spot.core.post.application.PostQueryService
+import kr.spot.core.post.domain.enums.PostType
+import kr.spot.core.post.presentation.query.dto.response.PostDetailResponse
+import kr.spot.core.post.presentation.query.dto.response.PostListResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestAttribute
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "게시글")
+@RestController
+@RequestMapping("/api/posts")
+class PostQueryController(
+    private val postQueryService: PostQueryService
+) {
+    @Operation(summary = "게시글 상세 조회")
+    @GetMapping("/{postId}")
+    fun getPostDetail(
+        @PathVariable postId: Long,
+        @RequestAttribute(value = "memberId", required = false) memberId: Long?
+    ): ApiResponse<PostDetailResponse> {
+        val response = postQueryService.getPostDetail(postId, memberId)
+        return ApiResponse.ok(response)
+    }
+
+    @Operation(summary = "게시글 목록 조회")
+    @GetMapping("")
+    fun getPostList(
+        @RequestParam(required = false) cursor: Long?,
+        @RequestParam(defaultValue = "20") size: Int,
+        @RequestParam(required = false) postType: PostType?,
+        @RequestAttribute(value = "memberId", required = false) memberId: Long?
+    ): ApiResponse<PostListResponse> {
+        val response = postQueryService.getPostList(cursor, size, postType, memberId)
+        return ApiResponse.ok(response)
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/post/presentation/query/dto/response/PostDetailResponse.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/presentation/query/dto/response/PostDetailResponse.kt
@@ -1,0 +1,63 @@
+package kr.spot.core.post.presentation.query.dto.response
+
+import kr.spot.core.post.domain.enums.PostType
+import java.time.LocalDateTime
+
+data class PostDetailResponse(
+    val postId: Long,
+    val title: String,
+    val content: String,
+    val imageUrl: String?,
+    val postType: PostType,
+    val isLiked: Boolean,
+    val isOwner: Boolean,
+    val writer: WriterInfoResponse,
+    val stats: PostStatsResponse,
+    val createdAt: LocalDateTime,
+    val comments: List<CommentResponse>,
+    val commentCount: Int
+) {
+    data class CommentResponse(
+        val commentId: Long,
+        val content: String,
+        val writer: WriterInfoResponse,
+        val createdAt: LocalDateTime
+    ) {
+        companion object {
+            fun of(
+                commentId: Long,
+                content: String,
+                writer: WriterInfoResponse,
+                createdAt: LocalDateTime
+            ) = CommentResponse(commentId, content, writer, createdAt)
+        }
+    }
+
+    data class WriterInfoResponse(
+        val writerId: Long,
+        val nickname: String,
+        val profileImageUrl: String?
+    ) {
+        companion object {
+            fun of(
+                writerId: Long,
+                nickname: String,
+                profileImageUrl: String?
+            ) = WriterInfoResponse(writerId, nickname, profileImageUrl)
+        }
+    }
+
+    data class PostStatsResponse(
+        val likeCount: Long,
+        val commentCount: Long,
+        val viewCount: Long
+    ) {
+        companion object {
+            fun of(
+                likeCount: Long,
+                commentCount: Long,
+                viewCount: Long
+            ) = PostStatsResponse(likeCount, commentCount, viewCount)
+        }
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/post/presentation/query/dto/response/PostListResponse.kt
+++ b/core/src/main/kotlin/kr/spot/core/post/presentation/query/dto/response/PostListResponse.kt
@@ -1,0 +1,46 @@
+package kr.spot.core.post.presentation.query.dto.response
+
+import kr.spot.core.post.domain.enums.PostType
+import java.time.LocalDateTime
+
+data class PostListResponse(
+    val posts: List<PostList>,
+    val hasNext: Boolean,
+    val nextCursor: Long?
+) {
+    data class PostList(
+        val postId: Long,
+        val title: String,
+        val content: String,
+        val postType: PostType,
+        val stats: PostStatsResponse,
+        val createdAt: LocalDateTime,
+        val isLiked: Boolean?
+    ) {
+        companion object {
+            fun of(
+                postId: Long,
+                title: String,
+                content: String,
+                postType: PostType,
+                stats: PostStatsResponse,
+                createdAt: LocalDateTime,
+                isLiked: Boolean?
+            ) = PostList(postId, title, content, postType, stats, createdAt, isLiked)
+        }
+    }
+
+    data class PostStatsResponse(
+        val likeCount: Long,
+        val commentCount: Long,
+        val viewCount: Long
+    ) {
+        companion object {
+            fun of(
+                likeCount: Long,
+                commentCount: Long,
+                viewCount: Long
+            ) = PostStatsResponse(likeCount, commentCount, viewCount)
+        }
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/shared/domain/BaseEntity.kt
+++ b/core/src/main/kotlin/kr/spot/core/shared/domain/BaseEntity.kt
@@ -1,0 +1,32 @@
+package kr.spot.core.shared.domain
+
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.MappedSuperclass
+import kr.spot.core.shared.domain.enums.Status
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseEntity {
+
+    @CreatedDate
+    var createdAt: LocalDateTime? = null
+        protected set
+
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null
+        protected set
+
+    @Enumerated(EnumType.STRING)
+    var status: Status = Status.ACTIVE
+        protected set
+
+    fun delete() {
+        this.status = Status.INACTIVE
+    }
+}

--- a/core/src/main/kotlin/kr/spot/core/shared/domain/enums/Status.kt
+++ b/core/src/main/kotlin/kr/spot/core/shared/domain/enums/Status.kt
@@ -1,0 +1,6 @@
+package kr.spot.core.shared.domain.enums
+
+enum class Status {
+    ACTIVE,
+    INACTIVE
+}

--- a/core/src/main/kotlin/kr/spot/core/shared/infrastructure/JpaConfig.kt
+++ b/core/src/main/kotlin/kr/spot/core/shared/infrastructure/JpaConfig.kt
@@ -1,0 +1,9 @@
+package kr.spot.core.shared.infrastructure
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+
+@Configuration
+@EnableJpaAuditing
+class JpaConfig {
+}

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/spot_core
     username: root
-    password: ${DB_PASSWORD}
+    password: 5167
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/spot_core
     username: root
-    password: 5167
+    password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
@@ -19,8 +19,3 @@ spring:
     properties:
       hibernate:
         format_sql: true
-
-token:
-  access-secret: ${ACCESS_SECRET}
-  access-token-expiration-time: 3600000  # 1시간
-  refresh-token-expiration-time: 86400000  # 24시간


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #1 

<br/>

## 🔎 작업 내용

- 기존 Ver.2 내 `member`, `auth`, `post` 모듈을 현재 `core` 모듈로 마이그레이션 진행 (`Java -> Kotlin`)
- `auth` 모듈 내 복잡한 인증/인가 로직은 단순화 진행 (회원 식별자 기반 처리)
- 그 외 모듈의 기능도 필수적인 것만 남도록 축소 

<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
