### PR TITLE
[Feature] 포인트 발급 일일 한도 제한 관련 로직 구현

### DIFF
--- a/core/boot/build.gradle.kts
+++ b/core/boot/build.gradle.kts
@@ -17,6 +17,9 @@ dependencies {
     // Spring Data JPA
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
+    // QueryDSL
+    implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+
     // Redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 

--- a/core/boot/src/main/kotlin/kr/spot/core/config/QueryDslConfig.kt
+++ b/core/boot/src/main/kotlin/kr/spot/core/config/QueryDslConfig.kt
@@ -1,0 +1,16 @@
+package kr.spot.core.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QueryDslConfig(
+    @PersistenceContext
+    private val entityManager: EntityManager
+) {
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory = JPAQueryFactory(entityManager)
+}

--- a/core/point/build.gradle.kts
+++ b/core/point/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     kotlin("plugin.spring")
     kotlin("plugin.jpa")
+    kotlin("kapt")
 }
 
 dependencies {
@@ -15,4 +16,10 @@ dependencies {
     // Test
     testImplementation("io.mockk:mockk:1.13.13")
     testImplementation("org.assertj:assertj-core:3.26.3")
+
+    // QueryDSL
+    implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+    kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
+    kapt("jakarta.annotation:jakarta.annotation-api")
+    kapt("jakarta.persistence:jakarta.persistence-api")
 }

--- a/core/point/src/main/kotlin/kr/spot/core/point/application/event/PointApplicationEventListener.kt
+++ b/core/point/src/main/kotlin/kr/spot/core/point/application/event/PointApplicationEventListener.kt
@@ -11,6 +11,7 @@ import kr.spot.core.point.domain.Point
 import kr.spot.core.point.domain.PointHistory
 import kr.spot.core.point.infrastrcuture.PointHistoryRepository
 import kr.spot.core.point.infrastrcuture.PointRepository
+import kr.spot.core.point.infrastrcuture.querydsl.PointCustomRepository
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
@@ -20,9 +21,11 @@ import java.time.LocalDateTime
 class PointApplicationEventListener(
     private val idGenerator: IdGenerator,
     private val pointRepository: PointRepository,
-    private val pointHistoryRepository: PointHistoryRepository
+    private val pointHistoryRepository: PointHistoryRepository,
+    private val pointCustomRepository: PointCustomRepository
 ) {
     companion object {
+        private const val DAILY_MAX_POINTS = 100L
         private const val DAILY_ATTENDANCE_POINTS = 10L
         private const val STREAK_7_DAYS_POINTS = 50L
         private const val STREAK_14_DAYS_POINTS = 100L
@@ -82,6 +85,23 @@ class PointApplicationEventListener(
             return
         }
 
+        val gainedPointsToday = pointCustomRepository.getGainedPointsToday(memberId, LocalDateTime.now())
+
+        if (gainedPointsToday >= DAILY_MAX_POINTS) {
+            return
+        }
+
+        val allowedAmount = minOf(amount, DAILY_MAX_POINTS - gainedPointsToday)
+        increasePointAndSave(point, allowedAmount, eventId, memberId, reason)
+    }
+
+    private fun increasePointAndSave(
+        point: Point,
+        amount: Long,
+        eventId: String,
+        memberId: Long,
+        reason: PointReason
+    ) {
         point.increaseAmount(amount)
         pointHistoryRepository.save(
             PointHistory.of(

--- a/core/point/src/main/kotlin/kr/spot/core/point/application/event/PointKafkaEventListener.kt
+++ b/core/point/src/main/kotlin/kr/spot/core/point/application/event/PointKafkaEventListener.kt
@@ -9,22 +9,29 @@ import kr.spot.common.id.IdGenerator
 import kr.spot.core.point.domain.PointHistory
 import kr.spot.core.point.infrastrcuture.PointHistoryRepository
 import kr.spot.core.point.infrastrcuture.PointRepository
+import kr.spot.core.point.infrastrcuture.querydsl.PointCustomRepository
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Component
+import java.time.LocalDateTime
 
 @Component
 class PointKafkaEventListener(
     eventMetrics: EventMetrics,
     private val idGenerator: IdGenerator,
     private val pointHistoryRepository: PointHistoryRepository,
-    private val pointRepository: PointRepository
+    private val pointRepository: PointRepository,
+    private val pointCustomRepository: PointCustomRepository
 ) : AbstractEventConsumer<PointGrantedEvent>(
         eventMetrics = eventMetrics,
         consumerGroup = "core-point"
     ) {
     private val log = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        private const val DAILY_MAX_POINTS = 100L
+    }
 
     @Transactional
     @KafkaListener(topics = [Topics.POINT_EVENTS], groupId = "core-point")
@@ -43,8 +50,16 @@ class PointKafkaEventListener(
                 return
             }
 
-        pointHistoryRepository.save(createHistory(event))
-        point.increaseAmount(event.points)
+        val gainedPointsToday = pointCustomRepository.getGainedPointsToday(event.memberId, LocalDateTime.now())
+
+        if (gainedPointsToday >= DAILY_MAX_POINTS) {
+            log.info("[Kafka] Daily limit reached - memberId: {}, gained: {}", event.memberId, gainedPointsToday)
+            return
+        }
+
+        val allowedAmount = minOf(event.points, DAILY_MAX_POINTS - gainedPointsToday)
+        pointHistoryRepository.save(createHistory(event, allowedAmount))
+        point.increaseAmount(allowedAmount)
     }
 
     private fun isDuplicate(eventId: String): Boolean {
@@ -55,12 +70,12 @@ class PointKafkaEventListener(
         return duplicated
     }
 
-    private fun createHistory(event: PointGrantedEvent): PointHistory =
+    private fun createHistory(event: PointGrantedEvent, points: Long): PointHistory =
         PointHistory.of(
             id = idGenerator.nextId(),
             eventId = event.eventId,
             memberId = event.memberId,
-            points = event.points,
+            points = points,
             reason = event.reason,
             referenceId = event.referenceId ?: 0L,
             grantedAt = event.grantedAt

--- a/core/point/src/main/kotlin/kr/spot/core/point/infrastrcuture/querydsl/PointCustomRepository.kt
+++ b/core/point/src/main/kotlin/kr/spot/core/point/infrastrcuture/querydsl/PointCustomRepository.kt
@@ -1,0 +1,8 @@
+package kr.spot.core.point.infrastrcuture.querydsl
+
+import java.time.LocalDateTime
+
+interface PointCustomRepository {
+
+    fun getGainedPointsToday(memberId: Long, now: LocalDateTime) : Long
+}

--- a/core/point/src/main/kotlin/kr/spot/core/point/infrastrcuture/querydsl/PointCustomRepositoryImpl.kt
+++ b/core/point/src/main/kotlin/kr/spot/core/point/infrastrcuture/querydsl/PointCustomRepositoryImpl.kt
@@ -1,0 +1,26 @@
+package kr.spot.core.point.infrastrcuture.querydsl
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import kr.spot.core.point.domain.QPointHistory
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class PointCustomRepositoryImpl(
+    private val query: JPAQueryFactory
+) : PointCustomRepository {
+
+    override fun getGainedPointsToday(memberId: Long, now: LocalDateTime): Long {
+        val pointHistory = QPointHistory.pointHistory
+
+        return (query.select(pointHistory.points.sum())
+            .from(pointHistory)
+            .where(
+                pointHistory.memberId.eq(memberId),
+                pointHistory.grantedAt.goe(now.toLocalDate().atStartOfDay()),
+                pointHistory.grantedAt.loe(now)
+            )
+            .fetchOne() ?: 0L)
+    }
+}
+

--- a/core/point/src/test/kotlin/kr/spot/core/point/application/event/PointApplicationEventListenerTest.kt
+++ b/core/point/src/test/kotlin/kr/spot/core/point/application/event/PointApplicationEventListenerTest.kt
@@ -17,6 +17,7 @@ import kr.spot.core.point.domain.Point
 import kr.spot.core.point.domain.PointHistory
 import kr.spot.core.point.infrastrcuture.PointHistoryRepository
 import kr.spot.core.point.infrastrcuture.PointRepository
+import kr.spot.core.point.infrastrcuture.querydsl.PointCustomRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
@@ -36,6 +37,9 @@ class PointApplicationEventListenerTest {
 
     @MockK
     private lateinit var pointHistoryRepository: PointHistoryRepository
+
+    @MockK
+    private lateinit var pointCustomRepository: PointCustomRepository
 
     @InjectMockKs
     private lateinit var sut: PointApplicationEventListener
@@ -81,6 +85,7 @@ class PointApplicationEventListenerTest {
 
             every { pointRepository.findWithLockByMemberId(memberId) } returns point
             every { pointHistoryRepository.existsByEventId(any()) } returns false
+            every { pointCustomRepository.getGainedPointsToday(memberId, any()) } returns 0L
             every { idGenerator.nextId() } returns 100L
             every { pointHistoryRepository.save(any()) } returns mockk<PointHistory>()
 
@@ -108,6 +113,7 @@ class PointApplicationEventListenerTest {
 
             every { pointRepository.findWithLockByMemberId(memberId) } returns point
             every { pointHistoryRepository.existsByEventId(any()) } returns false
+            every { pointCustomRepository.getGainedPointsToday(memberId, any()) } returns 0L
             every { idGenerator.nextId() } returnsMany listOf(100L, 101L)
             every { pointHistoryRepository.save(capture(historySlots)) } returns mockk<PointHistory>()
 
@@ -140,6 +146,8 @@ class PointApplicationEventListenerTest {
 
             every { pointRepository.findWithLockByMemberId(memberId) } returns point
             every { pointHistoryRepository.existsByEventId(any()) } returns false
+            // 첫 번째 지급 후 10P, 두 번째 지급 시 이미 10P 받은 상태
+            every { pointCustomRepository.getGainedPointsToday(memberId, any()) } returnsMany listOf(0L, 10L)
             every { idGenerator.nextId() } returnsMany listOf(100L, 101L)
             every { pointHistoryRepository.save(any()) } returns mockk<PointHistory>()
 
@@ -147,7 +155,7 @@ class PointApplicationEventListenerTest {
             sut.handleAttendanceChecked(event)
 
             // then
-            assertThat(point.amount).isEqualTo(110L) // 10 + 100
+            assertThat(point.amount).isEqualTo(100L) // 10P + 90P (100P 제한으로 100P 중 90P만)
         }
 
         @Test
@@ -211,6 +219,7 @@ class PointApplicationEventListenerTest {
             every {
                 pointHistoryRepository.existsByEventId("${event.eventId}-one_week")
             } returns true
+            every { pointCustomRepository.getGainedPointsToday(memberId, any()) } returns 0L
             every { idGenerator.nextId() } returns 100L
             every { pointHistoryRepository.save(any()) } returns mockk<PointHistory>()
 
@@ -220,6 +229,92 @@ class PointApplicationEventListenerTest {
             // then
             assertThat(point.amount).isEqualTo(10L) // 일일 포인트만
             verify(exactly = 1) { pointHistoryRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("하루 최대 100P 제한은")
+    inner class DailyMaxPointsLimit {
+        @Test
+        fun `오늘 이미 100P를 받은 경우 포인트를 지급하지 않는다`() {
+            // given
+            val memberId = 1L
+            val point = Point.create(id = 1L, memberId = memberId)
+            val event =
+                AttendanceCheckedEvent(
+                    memberId = memberId,
+                    checkedDate = LocalDate.now(),
+                    currentStreak = 1,
+                    milestone = null
+                )
+
+            every { pointRepository.findWithLockByMemberId(memberId) } returns point
+            every { pointHistoryRepository.existsByEventId(any()) } returns false
+            every { pointCustomRepository.getGainedPointsToday(memberId, any()) } returns 100L
+
+            // when
+            sut.handleAttendanceChecked(event)
+
+            // then
+            assertThat(point.amount).isEqualTo(0L)
+            verify(exactly = 0) { pointHistoryRepository.save(any()) }
+        }
+
+        @Test
+        fun `지급하면 100P를 초과하는 경우 남은 만큼만 지급한다`() {
+            // given
+            val memberId = 1L
+            val point = Point.create(id = 1L, memberId = memberId)
+            val event =
+                AttendanceCheckedEvent(
+                    memberId = memberId,
+                    checkedDate = LocalDate.now(),
+                    currentStreak = 1,
+                    milestone = null
+                )
+            val historySlot = slot<PointHistory>()
+
+            every { pointRepository.findWithLockByMemberId(memberId) } returns point
+            every { pointHistoryRepository.existsByEventId(any()) } returns false
+            every { pointCustomRepository.getGainedPointsToday(memberId, any()) } returns 95L
+            every { idGenerator.nextId() } returns 100L
+            every { pointHistoryRepository.save(capture(historySlot)) } returns mockk<PointHistory>()
+
+            // when
+            sut.handleAttendanceChecked(event)
+
+            // then
+            assertThat(point.amount).isEqualTo(5L) // 100 - 95 = 5P만 지급
+            assertThat(historySlot.captured.points).isEqualTo(5L)
+            verify(exactly = 1) { pointHistoryRepository.save(any()) }
+        }
+
+        @Test
+        fun `오늘 90P를 받은 상태에서 10P 지급 요청 시 10P 전액 지급한다`() {
+            // given
+            val memberId = 1L
+            val point = Point.create(id = 1L, memberId = memberId)
+            val event =
+                AttendanceCheckedEvent(
+                    memberId = memberId,
+                    checkedDate = LocalDate.now(),
+                    currentStreak = 1,
+                    milestone = null
+                )
+            val historySlot = slot<PointHistory>()
+
+            every { pointRepository.findWithLockByMemberId(memberId) } returns point
+            every { pointHistoryRepository.existsByEventId(any()) } returns false
+            every { pointCustomRepository.getGainedPointsToday(memberId, any()) } returns 90L
+            every { idGenerator.nextId() } returns 100L
+            every { pointHistoryRepository.save(capture(historySlot)) } returns mockk<PointHistory>()
+
+            // when
+            sut.handleAttendanceChecked(event)
+
+            // then
+            assertThat(point.amount).isEqualTo(10L)
+            assertThat(historySlot.captured.points).isEqualTo(10L)
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #23

<br/>

## 🔎 작업 내용

- 포인트 발급 일일 한도 제한 관련 로직 구현 (하루 최대 100P)
- 지급하면 100P를 초과하는 경우 남은 만큼만 지급

<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
